### PR TITLE
Fixing the skill to use project ID not name

### DIFF
--- a/skills/arize-trace/SKILL.md
+++ b/skills/arize-trace/SKILL.md
@@ -13,7 +13,7 @@ description: "INVOKE THIS SKILL when downloading or exporting Arize traces and s
 
 Use `ax spans export` to download trace data. This is the only supported command for retrieving spans.
 
-**Resolving project for export:** Export commands require the project's **base64 ID** as `PROJECT`. (1) If the user's value looks like a base64 ID (long alphanumeric string, e.g. `TW9kZWw6NjUyMTA4NTQxMTpCbFZK`), use it as `PROJECT`. (2) If not (e.g. "financial_agent"), treat it as a project name: run `ax projects list --space-id SPACE_ID --limit 100 -o json`, find the project by `name`, and use its `id` as `PROJECT` in all export commands.
+**Resolving project for export:** The `PROJECT` positional argument accepts either a project name or a base64 project ID. When using a name, `--space-id` is required. If you hit limit errors or `401 Unauthorized` when using a project name, resolve it to a base64 ID: run `ax projects list --space-id SPACE_ID -l 100 -o json`, find the project by `name`, and use its `id` as `PROJECT`.
 
 **Exploratory export rule:** When exporting spans or traces **without** a specific `--trace-id`, `--span-id`, or `--session-id` (i.e., browsing/exploring a project), always start with `-l 50` to pull a small sample first. Summarize what you find, then pull more data only if the user asks or the task requires it. This avoids slow queries and overwhelming output on large projects.
 
@@ -21,7 +21,7 @@ Use `ax spans export` to download trace data. This is the only supported command
 
 ## Prerequisites
 
-Three things are needed: `ax` CLI, an API key (env var or profile), and a space ID. A **project ID** is required for export commands. If the user provides a project name, resolve it to the project ID (e.g. run `ax projects list --space-id SPACE_ID --limit 100 -o json`, find the project by `name`, then use its `id`).
+Three things are needed: `ax` CLI, an API key (env var or profile), and a space ID. A project name or ID is also needed but usually comes from the user's message.
 
 Run a **single** shell call to check everything at once (use `required_permissions: ["all"]`):
 
@@ -42,7 +42,7 @@ ax --version; Write-Host "--- env ---"; Write-Host "ARIZE_API_KEY: $env:ARIZE_AP
 - Space ID unknown → **AskQuestion**, or run `ax projects list -o json --limit 100 --space-id $ARIZE_SPACE_ID` and present as selectable options
 - Project unclear → ask, or run `ax projects list -o json --limit 100` and search for a match
 
-**IMPORTANT:** Export commands require the project's **base64 ID** as the `PROJECT` argument. If the user gives a project name, resolve it to an ID first (see above); do not pass the name as PROJECT.
+**IMPORTANT:** `--space-id` is required when using a human-readable project name as the `PROJECT` positional argument. It is not needed when using a base64-encoded project ID. If you hit `401 Unauthorized` or limit errors when using a project name, resolve it to a base64 ID first (see "Resolving project for export" in Concepts).
 
 ## Export Spans: `ax spans export`
 
@@ -73,8 +73,8 @@ ax spans export PROJECT_ID --session-id SESSION_ID --output-dir .arize-tmp-trace
 | `--trace-id` | string | mutex | Filter: `context.trace_id = 'X'` |
 | `--span-id` | string | mutex | Filter: `context.span_id = 'X'` |
 | `--session-id` | string | mutex | Filter: `attributes.session.id = 'X'` |
-| `PROJECT` | string (positional) | yes (or `$ARIZE_DEFAULT_PROJECT`) | Base64 project ID (positional arg, not a flag). If the user gives a project name, resolve it via `ax projects list --space-id SPACE_ID --limit 100 -o json` and use the project's `id`. |
-| `--space-id` | string | when using `--all` | Space ID; required for Arrow Flight (`--all`) only |
+| `PROJECT` | string (positional) | yes (or `$ARIZE_DEFAULT_PROJECT`) | Project name or base64 ID (positional arg, not a flag) |
+| `--space-id` | string | yes (when `PROJECT` is a name) | Space ID; required to resolve project names. Not needed when using a base64 project ID. Also required when using `--all` (Arrow Flight). |
 | `--days` | int | no | Lookback window (default: 30) |
 | `--start-time` | string | no | Override start (ISO 8601) |
 | `--end-time` | string | no | Override end (ISO 8601) |
@@ -138,9 +138,9 @@ ax traces export PROJECT_ID --space-id SPACE_ID --filter "status_code = 'ERROR'"
 
 | Flag | Type | Default | Description |
 |------|------|---------|-------------|
-| `PROJECT` | string | required | Base64 project ID (resolve name to ID via `ax projects list` if needed) |
+| `PROJECT` | string | required | Project name or base64 ID (positional arg) |
 | `--filter` | string | none | Filter expression for phase-1 span lookup |
-| `--space-id` | string | none | Space ID; required when using `--all` (Arrow Flight) |
+| `--space-id` | string | none | Space ID; required when `PROJECT` is a name or when using `--all` (Arrow Flight) |
 | `--limit, -l` | int | 50 | Max number of traces to export |
 | `--days` | int | 30 | Lookback window in days |
 | `--start-time` | string | none | Override start (ISO 8601) |
@@ -353,14 +353,14 @@ ax spans export PROJECT_ID --trace-id TRACE_ID --output-dir .arize-tmp-traces --
 | `ax: command not found` | Check `~/.local/bin/ax`; if missing: `uv tool install arize-ax-cli` (needs `required_permissions: ["all"]`) |
 | `No such command` on a subcommand that should exist | The installed `ax` is outdated. Reinstall from the local workspace: `uv tool install --force --reinstall /path/to/arize/sdk/python/arize-ax-cli` (needs `required_permissions: ["all"]`) |
 | `No profile found` | Follow "Resolve credentials" in Prerequisites to auto-discover or prompt for the API key |
-| `401 Unauthorized` with valid API key | Use the base64 project ID as PROJECT. If you have a project name, resolve it first: `ax projects list --space-id SPACE_ID --limit 100 -o json` and use the project's `id`. |
+| `401 Unauthorized` with valid API key | You are likely using a project name without `--space-id`. Add `--space-id SPACE_ID`, or resolve to a base64 project ID first: `ax projects list --space-id SPACE_ID -l 100 -o json` and use the project's `id`. |
 | `No spans found` | Expand `--days` (default 30), verify project ID |
 | `Filter error` | Check column name spelling, wrap string values in single quotes |
 | `Timeout on large export` | Use `--days 7` to narrow the time range |
 
 ## Save Credentials
 
-At session end, if the user manually provided an API key, space ID, or project ID (or name you resolved to an ID) (not loaded from an existing profile), offer to save them to `~/.arize/config.toml`. Use **AskQuestion** with "Yes, save them" / "No thanks". Skip if all values were already in the profile.
+At session end, if the user manually provided an API key, space ID, or project ID (not loaded from an existing profile), offer to save them to `~/.arize/config.toml`. Use **AskQuestion** with "Yes, save them" / "No thanks". Skip if all values were already in the profile.
 
 Read the existing file (or create it), add/update only the new fields, and write it back:
 


### PR DESCRIPTION
## arize-trace: require project ID for exports; resolve name → ID

**Problem:** Exporting by project name (e.g. "financial_agent") caused `ProjectsApi.projects_list` limit errors and a retry loop.

**Changes:**
- Prerequisites and IMPORTANT note: **project ID is required**; if the user gives a name, resolve it via `ax projects list --space-id SPACE_ID --limit 100 -o json` and use the project's `id`.
- Added "Resolving project for export" in Concepts: check base64 ID first; if not, resolve name → ID, then use ID for all exports.
- All export examples use `PROJECT_ID` only (no project-name + `--space-id` path). `--space-id` only when using `--all`.
- Flags tables and workflows updated to project ID; 401 troubleshooting points to resolve-by-name flow.

**File:** `skills/arize-trace/SKILL.md`