### PR TITLE
feat: use ax cli for trace verification on arize-trace skill

### DIFF
--- a/skills/arize-instrumentation/SKILL.md
+++ b/skills/arize-instrumentation/SKILL.md
@@ -163,7 +163,7 @@ See [Manual instrumentation](https://arize.com/docs/ax/observe/tracing/setup/man
 After implementation:
 
 1. Run the application and trigger at least one LLM call.
-2. **Use the `arize-trace` skill** to confirm traces arrived. Export recent spans with `ax spans export PROJECT --space-id $ARIZE_SPACE_ID -l 50 --output-dir .arize-tmp-traces --stdout` (or filter by `--session-id` if known). If empty, retry shortly. Verify spans have expected `openinference.span.kind`, `input.value`/`output.value`, and parent-child relationships.
+2. **Use the `arize-trace` skill** to confirm traces arrived. If empty, retry shortly. Verify spans have expected `openinference.span.kind`, `input.value`/`output.value`, and parent-child relationships.
 3. If no traces: verify `ARIZE_SPACE_ID` and `ARIZE_API_KEY`, ensure tracer is initialized before instrumentors and clients, check connectivity to `otlp.arize.com:443`; for debug set `GRPC_VERBOSITY=debug` or pass `log_to_console=True` to `register()`. Common gotchas: (a) missing project name resource attribute causes HTTP 500 rejections — `service.name` alone is not enough; Python: pass `project_name` to `register()`; TypeScript: set `"model_id"` or `SEMRESATTRS_PROJECT_NAME` on the resource; (b) CLI/script processes exit before OTLP exports flush — call `provider.force_flush()` then `provider.shutdown()` before exit.
 4. If the app uses tools: confirm CHAIN and TOOL spans appear with `input.value` / `output.value` so tool calls and results are visible.
 


### PR DESCRIPTION
  Summary                                                                                                                                                                                                                    
  - Replace UI-based verification step with arize-trace skill (ax CLI) for programmatic trace validation after instrumentation                                                                                                                
  - Add retry guidance for cases where traces haven't been ingested yet       