### PR TITLE
chore: Improve arize-trace skill

### DIFF
--- a/skills/arize-trace/SKILL.md
+++ b/skills/arize-trace/SKILL.md
@@ -62,7 +62,7 @@ ax --version; Write-Host "--- env ---"; Write-Host "ARIZE_API_KEY: $(if ($env:AR
 
 - No API key in env **and** no profile → **AskQuestion**: "Arize API key (https://app.arize.com/admin > API Keys)"
 - Space ID unknown → **AskQuestion**, or run `ax projects list -o json --limit 100 --space-id $ARIZE_SPACE_ID` and present as selectable options
-- Project unclear → ask, or run `ax projects list -o json --limit 100` and search for a match
+- Project unclear → run `ax projects list -l 100 -o json` (add `--space-id` if known), present the names, and ask the user to pick one
 
 **IMPORTANT:** `--space-id` is required when using a human-readable project name as the `PROJECT` positional argument. It is not needed when using a base64-encoded project ID. If you hit `401 Unauthorized` or limit errors when using a project name, resolve it to a base64 ID first (see "Resolving project for export" in Concepts).
 


### PR DESCRIPTION
- Add --filter and --limit to spans export flags table (were missing)
- Fix mutex constraint: --filter is a valid alternative to --trace-id/--span-id/--session-id
- Clarify --start-time/--end-time vs --days precedence
- Add specific filter syntax error messages to troubleshooting
- Add Related Skills section pointing to arize-dataset, arize-experiment, arize-prompt-optimization, arize-link