### PR TITLE
chore: improve arize-prompt-optimization skill

### DIFF
--- a/skills/arize-prompt-optimization/SKILL.md
+++ b/skills/arize-prompt-optimization/SKILL.md
@@ -254,87 +254,7 @@ Focus on **one metric at a time** — optimizing for multiple at once often make
 
 ### The Optimization Meta-Prompt
 
-Use this template to generate an improved version of the prompt. Fill in the three placeholders and send it to your LLM (GPT-4o, Claude, etc.):
-
-````
-You are an expert in prompt optimization. Given the original baseline prompt
-and the associated performance data (inputs, outputs, evaluation labels, and
-explanations), generate a revised version that improves results.
-
-CONSTRAINTS (do not violate these during optimization)
-======================================================
-
-{PASTE_ANY_HARD_CONSTRAINTS_HERE}
-Examples: "Output must be valid JSON", "Response must be under 200 tokens",
-"Must cite sources", "Must not change the output format schema",
-"Must preserve all {template_variables}"
-
-ORIGINAL BASELINE PROMPT
-========================
-
-{PASTE_ORIGINAL_PROMPT_HERE}
-
-========================
-
-PERFORMANCE DATA
-================
-
-The following records show how the current prompt performed. Each record
-includes the input, the LLM output, and evaluation feedback:
-
-{PASTE_RECORDS_HERE}
-
-================
-
-HOW TO USE THIS DATA
-
-1. Compare outputs: Look at what the LLM generated vs what was expected
-2. Review eval scores: Check which examples scored poorly and why
-3. Examine annotations: Human feedback shows what worked and what didn't
-4. Identify patterns: Look for common issues across multiple examples
-5. Focus on failures: The rows where the output DIFFERS from the expected
-   value are the ones that need fixing
-
-ALIGNMENT STRATEGY
-
-- If outputs have extra text or reasoning not present in the ground truth,
-  remove instructions that encourage explanation or verbose reasoning
-- If outputs are missing information, add instructions to include it
-- If outputs are in the wrong format, add explicit format instructions
-- Focus on the rows where the output differs from the target -- these are
-  the failures to fix
-
-RULES
-
-Maintain Structure:
-- Use the same template variables as the current prompt ({var} or {{var}})
-- Don't change sections that are already working
-- Preserve the exact return format instructions from the original prompt
-
-Avoid Overfitting:
-- DO NOT copy examples verbatim into the prompt
-- DO NOT quote specific test data outputs exactly
-- INSTEAD: Extract the ESSENCE of what makes good vs bad outputs
-- INSTEAD: Add general guidelines and principles
-- INSTEAD: If adding few-shot examples, create SYNTHETIC examples that
-  demonstrate the principle, not real data from above
-
-Goal: Create a prompt that generalizes well to new inputs, not one that
-memorizes the test data.
-
-OUTPUT FORMAT
-
-Return the revised prompt as a JSON array of messages:
-
-[
-  {"role": "system", "content": "..."},
-  {"role": "user", "content": "..."}
-]
-
-Also provide a brief reasoning section (bulleted list) explaining:
-- What problems you found
-- How the revised prompt addresses each one
-````
+See `meta-prompt.md` in this skill directory for the full template. Fill in the three placeholders (`{PASTE_ANY_HARD_CONSTRAINTS_HERE}`, `{PASTE_ORIGINAL_PROMPT_HERE}`, `{PASTE_RECORDS_HERE}`) and send it to your LLM (GPT-4o, Claude, etc.).
 
 ### Preparing the performance data
 
@@ -464,6 +384,14 @@ When optimizing prompts that use template variables:
 - Never add or remove variable placeholders during optimization
 - Never rename variables -- the runtime substitution depends on exact names
 - If adding few-shot examples, use literal values, not variable placeholders
+
+## Workflow Examples
+
+See `workflows.md` in this skill directory for end-to-end examples covering common scenarios:
+- Optimize a prompt from a failing trace
+- Optimize using a dataset and experiment
+- Debug a prompt that produces wrong format
+- Reduce hallucination in a RAG prompt
 
 ## Related Skills
 

--- a/skills/arize-prompt-optimization/meta-prompt.md
+++ b/skills/arize-prompt-optimization/meta-prompt.md
@@ -1,0 +1,83 @@
+# Optimization Meta-Prompt Template
+
+Use this template to generate an improved version of a prompt. Fill in the three placeholders and send it to your LLM (GPT-4o, Claude, etc.):
+
+````
+You are an expert in prompt optimization. Given the original baseline prompt
+and the associated performance data (inputs, outputs, evaluation labels, and
+explanations), generate a revised version that improves results.
+
+CONSTRAINTS (do not violate these during optimization)
+======================================================
+
+{PASTE_ANY_HARD_CONSTRAINTS_HERE}
+Examples: "Output must be valid JSON", "Response must be under 200 tokens",
+"Must cite sources", "Must not change the output format schema",
+"Must preserve all {template_variables}"
+
+ORIGINAL BASELINE PROMPT
+========================
+
+{PASTE_ORIGINAL_PROMPT_HERE}
+
+========================
+
+PERFORMANCE DATA
+================
+
+The following records show how the current prompt performed. Each record
+includes the input, the LLM output, and evaluation feedback:
+
+{PASTE_RECORDS_HERE}
+
+================
+
+HOW TO USE THIS DATA
+
+1. Compare outputs: Look at what the LLM generated vs what was expected
+2. Review eval scores: Check which examples scored poorly and why
+3. Examine annotations: Human feedback shows what worked and what didn't
+4. Identify patterns: Look for common issues across multiple examples
+5. Focus on failures: The rows where the output DIFFERS from the expected
+   value are the ones that need fixing
+
+ALIGNMENT STRATEGY
+
+- If outputs have extra text or reasoning not present in the ground truth,
+  remove instructions that encourage explanation or verbose reasoning
+- If outputs are missing information, add instructions to include it
+- If outputs are in the wrong format, add explicit format instructions
+- Focus on the rows where the output differs from the target -- these are
+  the failures to fix
+
+RULES
+
+Maintain Structure:
+- Use the same template variables as the current prompt ({var} or {{var}})
+- Don't change sections that are already working
+- Preserve the exact return format instructions from the original prompt
+
+Avoid Overfitting:
+- DO NOT copy examples verbatim into the prompt
+- DO NOT quote specific test data outputs exactly
+- INSTEAD: Extract the ESSENCE of what makes good vs bad outputs
+- INSTEAD: Add general guidelines and principles
+- INSTEAD: If adding few-shot examples, create SYNTHETIC examples that
+  demonstrate the principle, not real data from above
+
+Goal: Create a prompt that generalizes well to new inputs, not one that
+memorizes the test data.
+
+OUTPUT FORMAT
+
+Return the revised prompt as a JSON array of messages:
+
+[
+  {"role": "system", "content": "..."},
+  {"role": "user", "content": "..."}
+]
+
+Also provide a brief reasoning section (bulleted list) explaining:
+- What problems you found
+- How the revised prompt addresses each one
+````

--- a/skills/arize-prompt-optimization/workflows.md
+++ b/skills/arize-prompt-optimization/workflows.md
@@ -1,0 +1,68 @@
+# Prompt Optimization Workflows
+
+## Optimize a prompt from a failing trace
+
+1. Find failing traces:
+   ```bash
+   ax spans export PROJECT_ID --filter "status_code = 'ERROR' AND attributes.openinference.span.kind = 'LLM'" -l 5 --output-dir .arize-tmp-traces
+   ```
+2. Export the trace:
+   ```bash
+   ax spans export PROJECT_ID --trace-id TRACE_ID --output-dir .arize-tmp-traces
+   ```
+3. Extract the prompt from the LLM span:
+   ```bash
+   jq '[.[] | select(.attributes.openinference.span.kind == "LLM")][0] | {
+     messages: .attributes.llm.input_messages,
+     template: .attributes.llm.prompt_template,
+     output: .attributes.output.value,
+     error: .attributes.exception.message
+   }' trace_*/spans.json
+   ```
+4. Identify what failed from the error message or output
+5. Fill in the optimization meta-prompt (see `meta-prompt.md` in this skill directory) with the prompt and error context
+6. Apply the revised prompt
+
+## Optimize using a dataset and experiment
+
+1. Find the dataset and experiment:
+   ```bash
+   ax datasets list
+   ax experiments list --dataset-id DATASET_ID
+   ```
+2. Export both:
+   ```bash
+   ax datasets export DATASET_ID
+   ax experiments export EXPERIMENT_ID
+   ```
+3. Prepare the joined data for the meta-prompt
+4. Run the optimization meta-prompt (see `meta-prompt.md` in this skill directory)
+5. Create a new experiment with the revised prompt to measure improvement
+
+## Debug a prompt that produces wrong format
+
+1. Export spans where the output format is wrong:
+   ```bash
+   ax spans export PROJECT_ID \
+     --filter "attributes.openinference.span.kind = 'LLM' AND annotation.format.label = 'incorrect'" \
+     -l 10 --output-dir .arize-tmp-traces
+   ```
+2. Look at what the LLM is producing vs what was expected
+3. Add explicit format instructions to the prompt (JSON schema, examples, delimiters)
+4. Common fix: add a few-shot example showing the exact desired output format
+
+## Reduce hallucination in a RAG prompt
+
+1. Find traces where the model hallucinated:
+   ```bash
+   ax spans export PROJECT_ID \
+     --filter "annotation.faithfulness.label = 'unfaithful'" \
+     -l 20 --output-dir .arize-tmp-traces
+   ```
+2. Export and inspect the retriever + LLM spans together:
+   ```bash
+   ax spans export PROJECT_ID --trace-id TRACE_ID --output-dir .arize-tmp-traces
+   jq '[.[] | {kind: .attributes.openinference.span.kind, name, input: .attributes.input.value, output: .attributes.output.value}]' trace_*/spans.json
+   ```
+3. Check if the retrieved context actually contained the answer
+4. Add grounding instructions to the system prompt: "Only use information from the provided context. If the answer is not in the context, say so."


### PR DESCRIPTION
- Fix all ax spans export command syntax (positional PROJECT_ID, not --project flag)
- Replace undocumented ax spans list / ax traces list with ax spans export / ax traces export
- Add --output-dir .arize-tmp-traces to all export commands (was missing throughout)
- Add convergence criteria for iteration loop (stop conditions to prevent infinite loops)
- Add evaluation metric selection guide by use case (RAG, classification, agents, safety)
- Add prompt version tracking pattern (name experiments to reflect prompt version)
- Add constraint injection slot to meta-prompt template
- Add regression detection jq pattern to A/B comparison workflow
- Add Related Skills section pointing to arize-trace, arize-dataset, arize-experiment