### PR TITLE
chore: improve arize-dataset skill

### DIFF
--- a/skills/arize-dataset/SKILL.md
+++ b/skills/arize-dataset/SKILL.md
@@ -126,7 +126,7 @@ ax datasets get DATASET_ID -o json
 
 ## Export Dataset: `ax datasets export`
 
-Download all examples to a file. By default uses the REST API; pass `--all` to use Arrow Flight for bulk transfer.
+Download all examples to a file. Use `--all` for datasets larger than 500 examples (unlimited bulk export).
 
 ```bash
 ax datasets export DATASET_ID
@@ -145,26 +145,12 @@ ax datasets export DATASET_ID --stdout | jq '.[0]'
 |------|------|---------|-------------|
 | `DATASET_ID` | string | required | Positional argument |
 | `--version-id` | string | latest | Export a specific dataset version |
-| `--all` | bool | false | Use Arrow Flight for bulk export (see below) |
+| `--all` | bool | false | Unlimited bulk export (use for datasets > 500 examples) |
 | `--output-dir` | string | `.` | Output directory |
 | `--stdout` | bool | false | Print JSON to stdout instead of file |
 | `-p, --profile` | string | default | Configuration profile |
 
-### REST vs Flight (`--all`)
-
-- **REST** (default): Lower friction -- no Arrow/Flight dependency, standard HTTPS ports, works through any corporate proxy or firewall. Limited to 500 examples per page.
-- **Flight** (`--all`): Required for datasets with more than 500 examples. Uses gRPC+TLS on a separate host/port (`flight.arize.com:443`) which some corporate networks may block.
-
-**REST vs. Arrow Flight decision tree:**
-```
-How many examples does the dataset have?
-├─ < 500 → REST is fine (no --all needed)
-├─ ≥ 500 or unknown → use --all (Arrow Flight)
-│   └─ Arrow Flight times out? → contact support or export in version chunks
-└─ Just checking? → use REST with --stdout | jq 'length' to count first
-```
-
-**Agent auto-escalation rule:** If a REST export returns exactly 500 examples, the result is likely truncated. Re-run with `--all` to get the full dataset.
+**Agent auto-escalation rule:** If an export returns exactly 500 examples, the result is likely truncated — re-run with `--all` to get the full dataset.
 
 **Export completeness verification:** After exporting, confirm the row count matches what the server reports:
 ```bash
@@ -174,7 +160,7 @@ ax datasets get DATASET_ID -o json | jq '.versions[-1] | {version: .id, examples
 # Compare to what was exported
 jq 'length' dataset_*/examples.json
 
-# If counts differ and you used REST, re-export with --all
+# If counts differ, re-export with --all
 ```
 
 Output is a JSON array of example objects. Each example has system fields (`id`, `created_at`, `updated_at`) plus all user-defined fields:
@@ -207,9 +193,9 @@ ax datasets create --name "My Dataset" --space-id SPACE_ID --file data.parquet
 
 | Flag | Type | Required | Description |
 |------|------|----------|-------------|
-| `--name, -n` | string | yes (prompted) | Dataset name |
-| `--space-id` | string | yes (prompted) | Space to create the dataset in |
-| `--file, -f` | path | yes (prompted) | Data file: CSV, JSON, JSONL, or Parquet |
+| `--name, -n` | string | yes | Dataset name |
+| `--space-id` | string | yes | Space to create the dataset in |
+| `--file, -f` | path | yes | Data file: CSV, JSON, JSONL, or Parquet |
 | `-o, --output` | string | no | Output format for the returned dataset metadata |
 | `-p, --profile` | string | no | Configuration profile |
 
@@ -273,7 +259,6 @@ Exactly one of `--json` or `--file` is required.
 ### Validation
 
 - Each example must be a JSON object with at least one user-defined field
-- Fields `id`, `created_at`, `updated_at` are auto-generated -- do not include them
 - Maximum 100,000 examples per request
 
 **Schema validation before append:** If the dataset already has examples, inspect its schema before appending to avoid silent field mismatches:
@@ -332,13 +317,8 @@ ax datasets list -o json --limit 100 | jq '.[] | select(.name | test("eval-set")
 # Find the dataset
 ax datasets list
 
-# Append inline (e.g., from an LLM-generated payload)
-ax datasets append DATASET_ID --json '[
-  {"question": "What is gravity?", "answer": "A fundamental force..."},
-  {"question": "What is light?", "answer": "Electromagnetic radiation..."}
-]'
-
-# Or append from a file
+# Append inline or from a file (see Append Examples section for full syntax)
+ax datasets append DATASET_ID --json '[{"question": "...", "answer": "..."}]'
 ax datasets append DATASET_ID --file additional_examples.csv
 ```
 


### PR DESCRIPTION
- Add schema validation before append with field inspection pattern
- Simplify export section: replace REST vs Arrow Flight prose with auto-escalation rule (re-run with --all if result is exactly 500 examples)
- Add export completeness verification (compare row count to server metadata)
- Add format-specific gotchas (CSV loses types, JSONL vs JSON array, Parquet)
- Add find-dataset-by-name workflow using jq select
- Add Related Skills section pointing to arize-trace, arize-experiment, arize-prompt-optimization