### PR TITLE
Polish marketplace metadata for plugin directory

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,16 +1,23 @@
 {
-  "name": "Arize-ai-arize-skills",
+  "name": "arize-skills",
   "metadata": {
-    "description": "Skills for Arize observability and the ax CLI"
+    "description": "Official Arize AI skills for LLM observability — instrumentation, tracing, datasets, experiments, prompt optimization, and deep linking."
   },
   "owner": {
-    "name": "Arize AI"
+    "name": "Arize AI",
+    "email": "support@arize.com"
   },
   "plugins": [
     {
       "name": "arize-skills",
       "source": "./",
-      "description": "Trace export, dataset management, experiment workflows, instrumentation, prompt optimization, and deep linking via the ax CLI."
+      "description": "Add Arize AX observability to LLM applications — auto-instrumentation, trace export, dataset management, experiment workflows, prompt optimization, and deep linking via the ax CLI.",
+      "version": "1.0.0",
+      "keywords": ["arize", "observability", "tracing", "opentelemetry", "llm", "evals", "datasets", "experiments", "instrumentation"],
+      "category": "observability",
+      "homepage": "https://arize.com/docs/ax",
+      "repository": "https://github.com/Arize-ai/arize-skills",
+      "license": "Apache-2.0"
     }
   ]
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,13 +1,14 @@
 {
   "name": "arize-skills",
-  "version": "0.1.0",
-  "description": "Skills for Arize observability: trace export, dataset management, experiment workflows, instrumentation, prompt optimization, and deep linking via the ax CLI.",
+  "version": "1.0.0",
+  "description": "Add Arize AX observability to LLM applications — auto-instrumentation, trace export, dataset management, experiment workflows, prompt optimization, and deep linking via the ax CLI.",
   "author": {
     "name": "Arize AI",
+    "email": "support@arize.com",
     "url": "https://arize.com"
   },
   "homepage": "https://arize.com/docs/ax",
   "repository": "https://github.com/Arize-ai/arize-skills",
   "license": "Apache-2.0",
-  "keywords": ["arize", "tracing", "observability", "llm", "evals", "datasets", "experiments"]
+  "keywords": ["arize", "observability", "tracing", "opentelemetry", "llm", "evals", "datasets", "experiments", "instrumentation"]
 }


### PR DESCRIPTION
## Summary
- Fix marketplace name to kebab-case (`arize-skills` not `Arize-ai-arize-skills`)
- Bump version from `0.1.0` to `1.0.0`
- Add owner email, keywords, category, license, homepage, repository to marketplace plugin entry
- Improve descriptions to lead with value prop
- Add `opentelemetry` and `instrumentation` to keywords for discoverability

## Context
Polishing the `.claude-plugin/marketplace.json` and `plugin.json` so we show up well in the Claude Code plugin marketplace and claudemarketplaces.com (which auto-discovers repos with valid marketplace.json).

## How to test
```bash
# In Claude Code:
/plugin marketplace add Arize-ai/arize-skills
/plugin install arize-skills@arize-skills
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)