### PR TITLE
feat: AX setup reference docs

### DIFF
--- a/skills/arize-dataset/SKILL.md
+++ b/skills/arize-dataset/SKILL.md
@@ -20,24 +20,7 @@ Three things are needed: `ax` CLI, an API key (env var or profile), and a space 
 
 ### Install ax
 
-Verify `ax` is installed and working before proceeding:
-
-1. Check if `ax` is on PATH: `command -v ax` (Unix) or `where ax` (Windows)
-2. If not found, check common install locations:
-   - macOS/Linux: `test -x ~/.local/bin/ax && export PATH="$HOME/.local/bin:$PATH"`
-   - Windows: check `%APPDATA%\Python\Scripts\ax.exe` or `%LOCALAPPDATA%\Programs\Python\Scripts\ax.exe`
-3. If still not found, install it (requires shell access to install packages):
-   - Preferred: `uv tool install arize-ax-cli`
-   - Alternative: `pipx install arize-ax-cli`
-   - Fallback: `pip install arize-ax-cli`
-4. After install, if `ax` is not on PATH:
-   - macOS/Linux: `export PATH="$HOME/.local/bin:$PATH"`
-   - Windows (PowerShell): `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
-5. If `ax --version` fails with an SSL/certificate error:
-   - macOS: `export SSL_CERT_FILE=/etc/ssl/cert.pem`
-   - Linux: `export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`
-   - Windows (PowerShell): `$env:SSL_CERT_FILE = "C:\Program Files\Common Files\SSL\cert.pem"` (or use `python -c "import certifi; print(certifi.where())"` to find the cert bundle)
-6. `ax --version` must succeed before proceeding. If it doesn't, stop and ask the user for help.
+If `ax` is not installed, not on PATH, or below version `0.3.0`, see ax-setup.md.
 
 ### Verify environment
 
@@ -343,7 +326,7 @@ Examples are free-form JSON objects. There is no fixed schema -- columns are wha
 
 | Problem | Solution |
 |---------|----------|
-| `ax: command not found` | Check `~/.local/bin/ax`; if missing: `uv tool install arize-ax-cli` (requires shell access to install packages) |
+| `ax: command not found` | See ax-setup.md |
 | `401 Unauthorized` | API key may not have access to this space. Verify the key and space ID are correct. Keys are scoped per space -- get the right one from https://app.arize.com/admin > API Keys. |
 | `No profile found` | Run `ax profiles show --expand` to check; set `ARIZE_API_KEY` env var or write `~/.arize/config.toml` |
 | `Dataset not found` | Verify dataset ID with `ax datasets list` |

--- a/skills/arize-dataset/ax-setup.md
+++ b/skills/arize-dataset/ax-setup.md
@@ -1,0 +1,24 @@
+# ax CLI Setup
+
+Verify `ax` is installed and working before proceeding:
+
+1. Check if `ax` is on PATH: `command -v ax` (Unix) or `where ax` (Windows)
+2. If not found, check common install locations:
+   - macOS/Linux: `test -x ~/.local/bin/ax && export PATH="$HOME/.local/bin:$PATH"`
+   - Windows: check `%APPDATA%\Python\Scripts\ax.exe` or `%LOCALAPPDATA%\Programs\Python\Scripts\ax.exe`
+3. If still not found, install it (requires shell access to install packages):
+   - Preferred: `uv tool install arize-ax-cli`
+   - Alternative: `pipx install arize-ax-cli`
+   - Fallback: `pip install arize-ax-cli`
+4. After install, if `ax` is not on PATH:
+   - macOS/Linux: `export PATH="$HOME/.local/bin:$PATH"`
+   - Windows (PowerShell): `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
+5. If `ax --version` fails with an SSL/certificate error:
+   - macOS: `export SSL_CERT_FILE=/etc/ssl/cert.pem`
+   - Linux: `export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`
+   - Windows (PowerShell): `$env:SSL_CERT_FILE = "C:\Program Files\Common Files\SSL\cert.pem"` (or use `python -c "import certifi; print(certifi.where())"` to find the cert bundle)
+6. Check the version: `ax --version` must show `0.3.0` or higher. If the version is lower, upgrade it:
+   - `uv tool install --force --reinstall arize-ax-cli`
+   - `pipx upgrade arize-ax-cli`
+   - `pip install --upgrade arize-ax-cli`
+7. If `ax --version` fails entirely, stop and ask the user for help.

--- a/skills/arize-experiment/SKILL.md
+++ b/skills/arize-experiment/SKILL.md
@@ -20,24 +20,7 @@ Three things are needed: `ax` CLI, an API key (env var or profile), and a space 
 
 ### Install ax
 
-Verify `ax` is installed and working before proceeding:
-
-1. Check if `ax` is on PATH: `command -v ax` (Unix) or `where ax` (Windows)
-2. If not found, check common install locations:
-   - macOS/Linux: `test -x ~/.local/bin/ax && export PATH="$HOME/.local/bin:$PATH"`
-   - Windows: check `%APPDATA%\Python\Scripts\ax.exe` or `%LOCALAPPDATA%\Programs\Python\Scripts\ax.exe`
-3. If still not found, install it (requires shell access to install packages):
-   - Preferred: `uv tool install arize-ax-cli`
-   - Alternative: `pipx install arize-ax-cli`
-   - Fallback: `pip install arize-ax-cli`
-4. After install, if `ax` is not on PATH:
-   - macOS/Linux: `export PATH="$HOME/.local/bin:$PATH"`
-   - Windows (PowerShell): `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
-5. If `ax --version` fails with an SSL/certificate error:
-   - macOS: `export SSL_CERT_FILE=/etc/ssl/cert.pem`
-   - Linux: `export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`
-   - Windows (PowerShell): `$env:SSL_CERT_FILE = "C:\Program Files\Common Files\SSL\cert.pem"` (or use `python -c "import certifi; print(certifi.where())"` to find the cert bundle)
-6. `ax --version` must succeed before proceeding. If it doesn't, stop and ask the user for help.
+If `ax` is not installed, not on PATH, or below version `0.3.0`, see ax-setup.md.
 
 ### Verify environment
 
@@ -350,7 +333,7 @@ ax experiments export EXPERIMENT_ID --stdout | jq -r '.[] | [.example_id, .outpu
 
 | Problem | Solution |
 |---------|----------|
-| `ax: command not found` | Check `~/.local/bin/ax`; if missing: `uv tool install arize-ax-cli` (requires shell access to install packages) |
+| `ax: command not found` | See ax-setup.md |
 | `401 Unauthorized` | API key may not have access to this space. Verify the key and space ID are correct. Keys are scoped per space -- get the right one from https://app.arize.com/admin > API Keys. |
 | `No profile found` | Run `ax profiles show --expand` to check; set `ARIZE_API_KEY` env var or write `~/.arize/config.toml` |
 | `Experiment not found` | Verify experiment ID with `ax experiments list` |

--- a/skills/arize-experiment/ax-setup.md
+++ b/skills/arize-experiment/ax-setup.md
@@ -1,0 +1,24 @@
+# ax CLI Setup
+
+Verify `ax` is installed and working before proceeding:
+
+1. Check if `ax` is on PATH: `command -v ax` (Unix) or `where ax` (Windows)
+2. If not found, check common install locations:
+   - macOS/Linux: `test -x ~/.local/bin/ax && export PATH="$HOME/.local/bin:$PATH"`
+   - Windows: check `%APPDATA%\Python\Scripts\ax.exe` or `%LOCALAPPDATA%\Programs\Python\Scripts\ax.exe`
+3. If still not found, install it (requires shell access to install packages):
+   - Preferred: `uv tool install arize-ax-cli`
+   - Alternative: `pipx install arize-ax-cli`
+   - Fallback: `pip install arize-ax-cli`
+4. After install, if `ax` is not on PATH:
+   - macOS/Linux: `export PATH="$HOME/.local/bin:$PATH"`
+   - Windows (PowerShell): `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
+5. If `ax --version` fails with an SSL/certificate error:
+   - macOS: `export SSL_CERT_FILE=/etc/ssl/cert.pem`
+   - Linux: `export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`
+   - Windows (PowerShell): `$env:SSL_CERT_FILE = "C:\Program Files\Common Files\SSL\cert.pem"` (or use `python -c "import certifi; print(certifi.where())"` to find the cert bundle)
+6. Check the version: `ax --version` must show `0.3.0` or higher. If the version is lower, upgrade it:
+   - `uv tool install --force --reinstall arize-ax-cli`
+   - `pipx upgrade arize-ax-cli`
+   - `pip install --upgrade arize-ax-cli`
+7. If `ax --version` fails entirely, stop and ask the user for help.

--- a/skills/arize-prompt-optimization/SKILL.md
+++ b/skills/arize-prompt-optimization/SKILL.md
@@ -50,24 +50,7 @@ Three things are needed: `ax` CLI, an API key (env var or profile), and a projec
 
 ### Install ax
 
-Verify `ax` is installed and working before proceeding:
-
-1. Check if `ax` is on PATH: `command -v ax` (Unix) or `where ax` (Windows)
-2. If not found, check common install locations:
-   - macOS/Linux: `test -x ~/.local/bin/ax && export PATH="$HOME/.local/bin:$PATH"`
-   - Windows: check `%APPDATA%\Python\Scripts\ax.exe` or `%LOCALAPPDATA%\Programs\Python\Scripts\ax.exe`
-3. If still not found, install it (requires shell access to install packages):
-   - Preferred: `uv tool install arize-ax-cli`
-   - Alternative: `pipx install arize-ax-cli`
-   - Fallback: `pip install arize-ax-cli`
-4. After install, if `ax` is not on PATH:
-   - macOS/Linux: `export PATH="$HOME/.local/bin:$PATH"`
-   - Windows (PowerShell): `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
-5. If `ax --version` fails with an SSL/certificate error:
-   - macOS: `export SSL_CERT_FILE=/etc/ssl/cert.pem`
-   - Linux: `export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`
-   - Windows (PowerShell): `$env:SSL_CERT_FILE = "C:\Program Files\Common Files\SSL\cert.pem"` (or use `python -c "import certifi; print(certifi.where())"` to find the cert bundle)
-6. `ax --version` must succeed before proceeding. If it doesn't, stop and ask the user for help.
+If `ax` is not installed, not on PATH, or below version `0.3.0`, see ax-setup.md.
 
 ### Verify environment
 
@@ -479,7 +462,7 @@ When optimizing prompts that use template variables:
 
 | Problem | Solution |
 |---------|----------|
-| `ax: command not found` | **macOS/Linux:** check `~/.local/bin/ax`. **Windows:** check if `ax` is on PATH. If missing: `uv tool install arize-ax-cli` (requires shell access to install packages) |
+| `ax: command not found` | See ax-setup.md |
 | `No profile found` | Create `~/.arize/config.toml` with `api_key = "${ARIZE_API_KEY}"` (see Prerequisites) |
 | No `input_messages` on span | Check span kind -- Chain/Agent spans store prompts on child LLM spans, not on themselves |
 | Prompt template is `null` | Not all instrumentations emit `prompt_template`. Use `input_messages` or `input.value` instead |

--- a/skills/arize-prompt-optimization/ax-setup.md
+++ b/skills/arize-prompt-optimization/ax-setup.md
@@ -1,0 +1,24 @@
+# ax CLI Setup
+
+Verify `ax` is installed and working before proceeding:
+
+1. Check if `ax` is on PATH: `command -v ax` (Unix) or `where ax` (Windows)
+2. If not found, check common install locations:
+   - macOS/Linux: `test -x ~/.local/bin/ax && export PATH="$HOME/.local/bin:$PATH"`
+   - Windows: check `%APPDATA%\Python\Scripts\ax.exe` or `%LOCALAPPDATA%\Programs\Python\Scripts\ax.exe`
+3. If still not found, install it (requires shell access to install packages):
+   - Preferred: `uv tool install arize-ax-cli`
+   - Alternative: `pipx install arize-ax-cli`
+   - Fallback: `pip install arize-ax-cli`
+4. After install, if `ax` is not on PATH:
+   - macOS/Linux: `export PATH="$HOME/.local/bin:$PATH"`
+   - Windows (PowerShell): `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
+5. If `ax --version` fails with an SSL/certificate error:
+   - macOS: `export SSL_CERT_FILE=/etc/ssl/cert.pem`
+   - Linux: `export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`
+   - Windows (PowerShell): `$env:SSL_CERT_FILE = "C:\Program Files\Common Files\SSL\cert.pem"` (or use `python -c "import certifi; print(certifi.where())"` to find the cert bundle)
+6. Check the version: `ax --version` must show `0.3.0` or higher. If the version is lower, upgrade it:
+   - `uv tool install --force --reinstall arize-ax-cli`
+   - `pipx upgrade arize-ax-cli`
+   - `pip install --upgrade arize-ax-cli`
+7. If `ax --version` fails entirely, stop and ask the user for help.

--- a/skills/arize-trace/SKILL.md
+++ b/skills/arize-trace/SKILL.md
@@ -25,24 +25,7 @@ Three things are needed: `ax` CLI, an API key (env var or profile), and a space 
 
 ### Install ax
 
-Verify `ax` is installed and working before proceeding:
-
-1. Check if `ax` is on PATH: `command -v ax` (Unix) or `where ax` (Windows)
-2. If not found, check common install locations:
-   - macOS/Linux: `test -x ~/.local/bin/ax && export PATH="$HOME/.local/bin:$PATH"`
-   - Windows: check `%APPDATA%\Python\Scripts\ax.exe` or `%LOCALAPPDATA%\Programs\Python\Scripts\ax.exe`
-3. If still not found, install it (requires shell access to install packages):
-   - Preferred: `uv tool install arize-ax-cli`
-   - Alternative: `pipx install arize-ax-cli`
-   - Fallback: `pip install arize-ax-cli`
-4. After install, if `ax` is not on PATH:
-   - macOS/Linux: `export PATH="$HOME/.local/bin:$PATH"`
-   - Windows (PowerShell): `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
-5. If `ax --version` fails with an SSL/certificate error:
-   - macOS: `export SSL_CERT_FILE=/etc/ssl/cert.pem`
-   - Linux: `export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`
-   - Windows (PowerShell): `$env:SSL_CERT_FILE = "C:\Program Files\Common Files\SSL\cert.pem"` (or use `python -c "import certifi; print(certifi.where())"` to find the cert bundle)
-6. `ax --version` must succeed before proceeding. If it doesn't, stop and ask the user for help.
+If `ax` is not installed, not on PATH, or below version `0.3.0`, see ax-setup.md.
 
 ### Verify environment
 
@@ -388,7 +371,7 @@ ax spans export PROJECT_ID --trace-id TRACE_ID --stdout | jq '.[]'
 
 | Problem | Solution |
 |---------|----------|
-| `ax: command not found` | Check `~/.local/bin/ax`; if missing: `uv tool install arize-ax-cli` (requires shell access to install packages). Then `export PATH="$HOME/.local/bin:$PATH"` |
+| `ax: command not found` | See ax-setup.md |
 | `SSL: CERTIFICATE_VERIFY_FAILED` | macOS: `export SSL_CERT_FILE=/etc/ssl/cert.pem`. Linux: `export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`. Windows: `$env:SSL_CERT_FILE = (python -c "import certifi; print(certifi.where())")` |
 | `No such command` on a subcommand that should exist | The installed `ax` is outdated. Reinstall: `uv tool install --force --reinstall arize-ax-cli` (requires shell access to install packages) |
 | `No profile found` | Follow "Resolve credentials" in Prerequisites to auto-discover or prompt for the API key |

--- a/skills/arize-trace/ax-setup.md
+++ b/skills/arize-trace/ax-setup.md
@@ -1,0 +1,24 @@
+# ax CLI Setup
+
+Verify `ax` is installed and working before proceeding:
+
+1. Check if `ax` is on PATH: `command -v ax` (Unix) or `where ax` (Windows)
+2. If not found, check common install locations:
+   - macOS/Linux: `test -x ~/.local/bin/ax && export PATH="$HOME/.local/bin:$PATH"`
+   - Windows: check `%APPDATA%\Python\Scripts\ax.exe` or `%LOCALAPPDATA%\Programs\Python\Scripts\ax.exe`
+3. If still not found, install it (requires shell access to install packages):
+   - Preferred: `uv tool install arize-ax-cli`
+   - Alternative: `pipx install arize-ax-cli`
+   - Fallback: `pip install arize-ax-cli`
+4. After install, if `ax` is not on PATH:
+   - macOS/Linux: `export PATH="$HOME/.local/bin:$PATH"`
+   - Windows (PowerShell): `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
+5. If `ax --version` fails with an SSL/certificate error:
+   - macOS: `export SSL_CERT_FILE=/etc/ssl/cert.pem`
+   - Linux: `export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`
+   - Windows (PowerShell): `$env:SSL_CERT_FILE = "C:\Program Files\Common Files\SSL\cert.pem"` (or use `python -c "import certifi; print(certifi.where())"` to find the cert bundle)
+6. Check the version: `ax --version` must show `0.3.0` or higher. If the version is lower, upgrade it:
+   - `uv tool install --force --reinstall arize-ax-cli`
+   - `pipx upgrade arize-ax-cli`
+   - `pip install --upgrade arize-ax-cli`
+7. If `ax --version` fails entirely, stop and ask the user for help.


### PR DESCRIPTION
This introduces a setup script that can be referenced as needed. This avoids unnecessary context going with the agent.