### PR TITLE
fix: add missing --classification-choices flag and data granularity docs to evaluator skill

### DIFF
--- a/skills/arize-evaluator/SKILL.md
+++ b/skills/arize-evaluator/SKILL.md
@@ -82,9 +82,9 @@ For **session** granularity, the same trace-level grouping happens first, then t
 
 ### The `{conversation}` template variable
 
-Session-level evaluators unlock a special `{conversation}` template variable. It renders as a JSON array of `{input, output}` turns across all traces in the session, built from `attributes.input.value` / `attributes.llm.input_messages` (input side) and `attributes.output.value` / `attributes.llm.output_messages` (output side).
+At session granularity, `{conversation}` is a special template variable that renders as a JSON array of `{input, output}` turns across all traces in the session, built from `attributes.input.value` / `attributes.llm.input_messages` (input side) and `attributes.output.value` / `attributes.llm.output_messages` (output side).
 
-Using `{conversation}` with span or trace granularity causes an error — it is session-only.
+At span or trace granularity, `{conversation}` is treated as a regular template variable and resolved via column mappings like any other.
 
 ### Multi-evaluator tasks
 


### PR DESCRIPTION
## Summary

- Add `--classification-choices` (required) to all `ax evaluators create` and `create-version` examples
- Add `--classification-choices`, `--data-granularity`, `--provider-params` to the flag table
- Add a Data Granularity reference section (span vs trace vs session semantics, column prefixes, `{conversation}` variable, multi-evaluator behavior)
- Update best practices to reference `--classification-choices` instead of the UI

## Context

Dogfooding feedback reported task runs failing with "missing rails and classification choices" because the skill never included the `--classification-choices` flag. This was why many of the tasks were failing.

Also, when testing locally, I realized the skill could not create trace/session evals, so added that to the skills as well.