### PR TITLE
fix(instrumentation): replace broken API keys URL with ax profiles flow

### DIFF
--- a/skills/arize-instrumentation/SKILL.md
+++ b/skills/arize-instrumentation/SKILL.md
@@ -107,7 +107,7 @@ Proceed **only after the user confirms** the Phase 1 analysis.
 3. **Credentials** — User needs an **Arize API Key** and **Space ID**. Check `.env` or existing `ax` profiles for `ARIZE_API_KEY` and `ARIZE_SPACE`:
    - Run `ax profiles show` to check for an existing profile.
    - If no profile exists, guide the user to run `ax profiles create` which provides an **interactive wizard** that walks through API key and space setup. See [CLI profiles docs](https://arize.com/docs/api-clients/cli/profiles) for details.
-   - If the user needs to find their API key manually, direct them to **https://app.arize.com/admin > API Keys** (do not use organization-specific URLs with placeholder IDs — they won't resolve for new users).
+   - If the user needs to find their API key manually, direct them to **https://app.arize.com** and to navigate to the settings page (do not use organization-specific URLs with placeholder IDs — they won't resolve for new users).
    - If credentials are not set, instruct the user to set them as environment variables — never embed raw values in generated code. All generated instrumentation code must reference `os.environ["ARIZE_API_KEY"]` (Python) or `process.env.ARIZE_API_KEY` (TypeScript/JavaScript).
    - See references/ax-profiles.md for full profile setup and troubleshooting.
 4. **Centralized instrumentation** — Create a single module (e.g. `instrumentation.py`, `instrumentation.ts`) and initialize tracing **before** any LLM client is created.

--- a/skills/arize-instrumentation/SKILL.md
+++ b/skills/arize-instrumentation/SKILL.md
@@ -104,7 +104,12 @@ Proceed **only after the user confirms** the Phase 1 analysis.
    - Python: `pip install arize-otel` plus `openinference-instrumentation-{name}` (hyphens in package name; underscores in import, e.g. `openinference.instrumentation.llama_index`).
    - TypeScript/JavaScript: `@opentelemetry/sdk-trace-node` plus the relevant `@arizeai/openinference-*` package.
    - Java: OpenTelemetry SDK plus `openinference-instrumentation-*` in pom.xml or build.gradle.
-3. **Credentials** — User needs **Arize Space ID** and **API Key** from [Space API Keys](https://app.arize.com/organizations/-/settings/space-api-keys). Check `.env` for `ARIZE_API_KEY` and `ARIZE_SPACE`. If not found, instruct the user to set them as environment variables — never embed raw values in generated code. All generated instrumentation code must reference `os.environ["ARIZE_API_KEY"]` (Python) or `process.env.ARIZE_API_KEY` (TypeScript/JavaScript).
+3. **Credentials** — User needs an **Arize API Key** and **Space ID**. Check `.env` or existing `ax` profiles for `ARIZE_API_KEY` and `ARIZE_SPACE`:
+   - Run `ax profiles show` to check for an existing profile.
+   - If no profile exists, guide the user to run `ax profiles create` which provides an **interactive wizard** that walks through API key and space setup. See [CLI profiles docs](https://arize.com/docs/api-clients/cli/profiles) for details.
+   - If the user needs to find their API key manually, direct them to **https://app.arize.com/admin > API Keys** (do not use organization-specific URLs with placeholder IDs — they won't resolve for new users).
+   - If credentials are not set, instruct the user to set them as environment variables — never embed raw values in generated code. All generated instrumentation code must reference `os.environ["ARIZE_API_KEY"]` (Python) or `process.env.ARIZE_API_KEY` (TypeScript/JavaScript).
+   - See references/ax-profiles.md for full profile setup and troubleshooting.
 4. **Centralized instrumentation** — Create a single module (e.g. `instrumentation.py`, `instrumentation.ts`) and initialize tracing **before** any LLM client is created.
 5. **Existing OTel** — If there is already a TracerProvider, add Arize as an **additional** exporter (e.g. BatchSpanProcessor with Arize OTLP). Do not replace existing setup unless the user asks.
 

--- a/skills/arize-instrumentation/references/ax-profiles.md
+++ b/skills/arize-instrumentation/references/ax-profiles.md
@@ -67,7 +67,7 @@ If `ARIZE_API_KEY` is not already set, instruct the user to export it in their s
 export ARIZE_API_KEY="..."   # user pastes their key here in their own terminal
 ```
 
-They can find their key at https://app.arize.com/admin > API Keys. Recommend they create a **scoped service key** (not a personal user key) — service keys are not tied to an individual account and are safer for programmatic use. Keys are space-scoped — make sure they copy the key for the correct space.
+They can find their key at https://app.arize.com by navigating to the settings page. Recommend they create a **scoped service key** (not a personal user key) — service keys are not tied to an individual account and are safer for programmatic use. Keys are space-scoped — make sure they copy the key for the correct space.
 
 Once the user confirms the variable is set, proceed with `ax profiles create --api-key $ARIZE_API_KEY` or `ax profiles update --api-key $ARIZE_API_KEY` as described above.
 


### PR DESCRIPTION
## Summary

- The instrumentation skill's Phase 2 credentials step linked to `app.arize.com/organizations/-/settings/space-api-keys` — a URL with a `-` placeholder org ID that can't resolve for new users, landing them on a broken/empty page
- Replaced with guidance to use `ax profiles create` (interactive wizard that walks through full setup) as the primary path, with `app.arize.com/admin > API Keys` as the manual fallback
- Added a pointer to the existing `references/ax-profiles.md` for full troubleshooting

Reported by Isabella Berry in [#eng-llm-evals](https://arizeai.slack.com/archives/C0ALAD9HNNL/p1776367052843219).

## Test plan

- [ ] Run the instrumentation skill against a fresh project without an existing `ax` profile — confirm it guides the user through `ax profiles create` instead of linking to the broken URL
- [ ] Run the instrumentation skill with an existing profile — confirm it detects the profile via `ax profiles show` and proceeds normally