### PR TITLE
fix: address dogfooding feedback across experiment and evaluator skills

### DIFF
--- a/skills/arize-ai-provider-integration/SKILL.md
+++ b/skills/arize-ai-provider-integration/SKILL.md
@@ -21,9 +21,10 @@ Proceed directly with the task — run the `ax` command you need. Do NOT check v
 
 If an `ax` command fails, troubleshoot based on the error:
 - `command not found` or version error → see references/ax-setup.md
-- `401 Unauthorized` / missing API key → run `ax profiles show` to inspect the current profile. If the profile is missing or the API key is wrong: check `.env` for `ARIZE_API_KEY` and use it to create/update the profile via references/ax-profiles.md. If `.env` has no key either, ask the user for their Arize API key (https://app.arize.com/admin > API Keys)
-- Space unknown → check `.env` for `ARIZE_SPACE` (name or ID), or run `ax spaces list` to pick by name, or ask the user
-- LLM provider call fails (missing OPENAI_API_KEY / ANTHROPIC_API_KEY) → check `.env`, load if present, otherwise ask the user
+- `401 Unauthorized` / missing API key → run `ax profiles show` to inspect the current profile. If the profile is missing or the API key is wrong, follow references/ax-profiles.md to create/update it. If the user doesn't have their key, direct them to https://app.arize.com/admin > API Keys
+- Space unknown → run `ax spaces list` to pick by name, or ask the user
+- LLM provider call fails (missing OPENAI_API_KEY / ANTHROPIC_API_KEY) → run `ax ai-integrations list --space SPACE` to check for platform-managed credentials. If none exist, ask the user to provide the key or create an integration via the **arize-ai-provider-integration** skill
+- **Security:** Never read `.env` files or search the filesystem for credentials. Use `ax profiles` for Arize credentials and `ax ai-integrations` for LLM provider keys. If credentials are not available through these channels, ask the user.
 
 ---
 

--- a/skills/arize-annotation/SKILL.md
+++ b/skills/arize-annotation/SKILL.md
@@ -19,8 +19,9 @@ Proceed directly with the task — run the `ax` command you need. Do NOT check v
 
 If an `ax` command fails, troubleshoot based on the error:
 - `command not found` or version error → see references/ax-setup.md
-- `401 Unauthorized` / missing API key → run `ax profiles show` to inspect the current profile. If the profile is missing or the API key is wrong: check `.env` for `ARIZE_API_KEY` and use it to create/update the profile via references/ax-profiles.md. If `.env` has no key either, ask the user for their Arize API key (https://app.arize.com/admin > API Keys)
-- Space unknown → check `.env` for `ARIZE_SPACE` (name or ID), or run `ax spaces list` to pick by name, or ask the user
+- `401 Unauthorized` / missing API key → run `ax profiles show` to inspect the current profile. If the profile is missing or the API key is wrong, follow references/ax-profiles.md to create/update it. If the user doesn't have their key, direct them to https://app.arize.com/admin > API Keys
+- Space unknown → run `ax spaces list` to pick by name, or ask the user
+- **Security:** Never read `.env` files or search the filesystem for credentials. Use `ax profiles` for Arize credentials and `ax ai-integrations` for LLM provider keys. If credentials are not available through these channels, ask the user.
 
 ---
 

--- a/skills/arize-dataset/SKILL.md
+++ b/skills/arize-dataset/SKILL.md
@@ -22,9 +22,10 @@ Proceed directly with the task — run the `ax` command you need. Do NOT check v
 
 If an `ax` command fails, troubleshoot based on the error:
 - `command not found` or version error → see references/ax-setup.md
-- `401 Unauthorized` / missing API key → run `ax profiles show` to inspect the current profile. If the profile is missing or the API key is wrong: check `.env` for `ARIZE_API_KEY` and use it to create/update the profile via references/ax-profiles.md. If `.env` has no key either, ask the user for their Arize API key (https://app.arize.com/admin > API Keys)
-- Space unknown → check `.env` for `ARIZE_SPACE` (name or ID), or run `ax spaces list` to pick by name, or ask the user
-- Project unclear → check `.env` for `ARIZE_DEFAULT_PROJECT`, or ask, or run `ax projects list -o json --limit 100` and present as selectable options
+- `401 Unauthorized` / missing API key → run `ax profiles show` to inspect the current profile. If the profile is missing or the API key is wrong, follow references/ax-profiles.md to create/update it. If the user doesn't have their key, direct them to https://app.arize.com/admin > API Keys
+- Space unknown → run `ax spaces list` to pick by name, or ask the user
+- Project unclear → ask the user, or run `ax projects list -o json --limit 100` and present as selectable options
+- **Security:** Never read `.env` files or search the filesystem for credentials. Use `ax profiles` for Arize credentials and `ax ai-integrations` for LLM provider keys. If credentials are not available through these channels, ask the user.
 
 ## List Datasets: `ax datasets list`
 

--- a/skills/arize-evaluator/SKILL.md
+++ b/skills/arize-evaluator/SKILL.md
@@ -17,9 +17,11 @@ Proceed directly with the task — run the `ax` command you need. Do NOT check v
 
 If an `ax` command fails, troubleshoot based on the error:
 - `command not found` or version error → see references/ax-setup.md
-- `401 Unauthorized` / missing API key → run `ax profiles show` to inspect the current profile. If the profile is missing or the API key is wrong: check `.env` for `ARIZE_API_KEY` and use it to create/update the profile via references/ax-profiles.md. If `.env` has no key either, ask the user for their Arize API key (https://app.arize.com/admin > API Keys)
-- Space unknown → check `.env` for `ARIZE_SPACE` (name or ID), or run `ax spaces list` to pick by name, or ask the user
-- LLM provider call fails (missing OPENAI_API_KEY / ANTHROPIC_API_KEY) → check `.env`, load if present, otherwise ask the user
+- `401 Unauthorized` / missing API key → run `ax profiles show` to inspect the current profile. If the profile is missing or the API key is wrong, follow references/ax-profiles.md to create/update it. If the user doesn't have their key, direct them to https://app.arize.com/admin > API Keys
+- Space unknown → run `ax spaces list` to pick by name, or ask the user
+- LLM provider call fails (missing OPENAI_API_KEY / ANTHROPIC_API_KEY) → run `ax ai-integrations list --space SPACE` to check for platform-managed credentials. If none exist, ask the user to provide the key or create an integration via the **arize-ai-provider-integration** skill
+- **Security:** Never read `.env` files or search the filesystem for credentials. Use `ax profiles` for Arize credentials and `ax ai-integrations` for LLM provider keys. If credentials are not available through these channels, ask the user.
+- **CRITICAL — Never fabricate evaluation results:** If an evaluation task fails, is cancelled, or produces no scores, report the failure clearly and explain what went wrong. Do NOT perform a "manual evaluation," invent quality scores, estimate percentages, or present any agent-generated analysis as if it came from the Arize evaluation system. Instead suggest: (1) fix the identified issue and retry, (2) try running from the Arize UI, (3) verify integration credentials with `ax ai-integrations list`, (4) contact support at https://arize.com/support
 
 ---
 
@@ -578,6 +580,77 @@ The labels in `--classification-choices` must exactly match the labels reference
 | Run failed: "missing rails and classification choices" | Add `--classification-choices '{"label_a": 1, "label_b": 0}'` to `ax evaluators create` — labels must match the template |
 | Run `completed`, all spans skipped | Query filter matched spans but column mappings are wrong or template variables don't resolve — export a sample span and verify paths |
 | `query_filter` set but 0 spans scored | The filter attribute may not be indexed in the eval index. `attributes.metadata.*` and custom attributes are often not indexed. Use `span_kind` or `attributes.llm.model_name` instead, or remove the filter to confirm spans exist in the window. |
+
+### Diagnosing cancelled runs
+
+When a task run is cancelled (status `cancelled`), follow this checklist in order:
+
+**1. Check integration credentials**
+```bash
+ax ai-integrations list --space SPACE -o json
+```
+Verify the integration ID used by the evaluator exists and has valid credentials. If the integration was deleted or the API key expired, the run cancels within ~1 second.
+
+**2. Verify the model name**
+```bash
+ax evaluators get EVALUATOR_NAME --space SPACE -o json
+```
+Check the `model_name` field. A typo or deprecated model causes the LLM call to fail and the run to cancel after ~3 minutes.
+
+**3. Export a sample span/run and compare paths to column_mappings**
+
+For project tasks:
+```bash
+ax spans export PROJECT --space SPACE -l 1 --days 7 --stdout | python3 -m json.tool
+```
+
+For experiment tasks:
+```bash
+ax experiments export EXPERIMENT_NAME --dataset DATASET_NAME --space SPACE --stdout | python3 -c "import sys,json; runs=json.load(sys.stdin); print(json.dumps(runs[0], indent=2)) if runs else print('No runs')"
+```
+
+Compare the exported JSON paths against the task's `column_mappings`. For each template variable, confirm the mapped path actually exists. Common mismatches:
+- Mapping `output` to `attributes.output.value` on an experiment run (should be just `output`)
+- Mapping `input` to `attributes.input.value` on a CHAIN span when the actual path is `attributes.llm.input_messages`
+- Mapping `context` to a path that doesn't exist on the span kind being filtered
+
+**4. Check that `data_start_time` is not epoch**
+
+If `trigger-run` used a start time of `0`, `1970-01-01`, or an empty string, the time window is invalid. Always derive from real span timestamps:
+```bash
+ax spans export PROJECT --space SPACE -l 5 --days 30 --stdout | python3 -c "
+import sys, json
+spans = json.load(sys.stdin)
+for s in spans:
+    print(s.get('start_time', 'N/A'), s.get('end_time', 'N/A'))
+"
+```
+
+**5. Verify span kind matches evaluator scope**
+
+If the evaluator was created with `--data-granularity trace` but the task's `query_filter` is `span_kind = 'LLM'`, the run may find no qualifying data and cancel. Ensure the granularity and filter are consistent.
+
+**6. Check that all template variables resolve**
+
+Every `{variable}` in the evaluator template must have a corresponding `column_mappings` entry that resolves to a non-null value. Test resolution against a real span:
+```bash
+ax spans export PROJECT --space SPACE -l 3 --days 7 --stdout | python3 -c "
+import sys, json
+spans = json.load(sys.stdin)
+# Replace these paths with your actual column_mappings values
+mappings = {'input': 'attributes.input.value', 'output': 'attributes.output.value'}
+for i, span in enumerate(spans):
+    print(f'--- Span {i} ---')
+    for var, path in mappings.items():
+        parts = path.split('.')
+        val = span
+        for p in parts:
+            val = val.get(p) if isinstance(val, dict) else None
+        status = 'FOUND' if val else 'MISSING'
+        print(f'  {var} ({path}): {status} — {str(val)[:80] if val else \"null\"}')
+"
+```
+If any variable shows MISSING on all spans, fix the column mapping or adjust `query_filter` to target a different span kind.
 
 ---
 

--- a/skills/arize-experiment/SKILL.md
+++ b/skills/arize-experiment/SKILL.md
@@ -22,9 +22,11 @@ Proceed directly with the task — run the `ax` command you need. Do NOT check v
 
 If an `ax` command fails, troubleshoot based on the error:
 - `command not found` or version error → see references/ax-setup.md
-- `401 Unauthorized` / missing API key → run `ax profiles show` to inspect the current profile. If the profile is missing or the API key is wrong: check `.env` for `ARIZE_API_KEY` and use it to create/update the profile via references/ax-profiles.md. If `.env` has no key either, ask the user for their Arize API key (https://app.arize.com/admin > API Keys)
-- Space unknown → check `.env` for `ARIZE_SPACE` (name or ID), or run `ax spaces list` to pick by name, or ask the user
-- Project unclear → check `.env` for `ARIZE_DEFAULT_PROJECT`, or ask, or run `ax projects list -o json --limit 100` and present as selectable options
+- `401 Unauthorized` / missing API key → run `ax profiles show` to inspect the current profile. If the profile is missing or the API key is wrong, follow references/ax-profiles.md to create/update it. If the user doesn't have their key, direct them to https://app.arize.com/admin > API Keys
+- Space unknown → run `ax spaces list` to pick by name, or ask the user
+- Project unclear → ask the user, or run `ax projects list -o json --limit 100` and present as selectable options
+- **Security:** Never read `.env` files or search the filesystem for credentials. Use `ax profiles` for Arize credentials and `ax ai-integrations` for LLM provider keys. If credentials are not available through these channels, ask the user.
+- **CRITICAL — Never fabricate outputs:** When running an experiment, you MUST call the real model API specified by the user for every dataset example. Never fabricate, simulate, or hardcode model outputs, latencies, or evaluation scores. If you cannot call the API (missing SDK, missing credentials, network error), stop and tell the user what is needed before proceeding.
 
 ## List Experiments: `ax experiments list`
 
@@ -235,14 +237,70 @@ At least one of `label`, `score`, or `explanation` should be present per evaluat
    ```bash
    ax datasets export DATASET_NAME --space SPACE
    ```
-3. Process each example through your system, collecting outputs and evaluations
-4. Build a runs file (JSON array) with `example_id`, `output`, and optional `evaluations`:
-   ```json
-   [
-     {"example_id": "ex_001", "output": "4", "evaluations": {"correctness": {"label": "correct", "score": 1.0}}},
-     {"example_id": "ex_002", "output": "Paris", "evaluations": {"correctness": {"label": "correct", "score": 1.0}}}
-   ]
+3. Call the real model API for each example and collect outputs. Use `ax datasets export --stdout` to pipe examples directly into an inference script:
+
+   ```bash
+   ax datasets export DATASET_NAME --space SPACE --stdout | python3 infer.py > runs.json
    ```
+
+   Write `infer.py` to read examples from stdin, call the target model, and write runs JSON to stdout. The script below is a template — first inspect the exported dataset JSON to find the correct input field name, then uncomment the provider block the user wants:
+
+   ```python
+   import json, sys, time
+
+   examples = json.load(sys.stdin)
+   runs = []
+
+   for ex in examples:
+       # Inspect the exported JSON to find the right field (e.g. "input", "question", "prompt")
+       user_input = ex.get("input") or ex.get("question") or ex.get("prompt") or str(ex)
+
+       start = time.time()
+
+       # === CALL THE REAL MODEL API HERE — never fabricate or simulate ===
+       # Uncomment and adapt the provider block the user requested:
+       #
+       # OpenAI (pip install openai  — uses OPENAI_API_KEY env var):
+       #   from openai import OpenAI
+       #   resp = OpenAI().chat.completions.create(
+       #       model="gpt-4o",
+       #       messages=[{"role": "user", "content": user_input}]
+       #   )
+       #   output_text = resp.choices[0].message.content
+       #
+       # Anthropic (pip install anthropic  — uses ANTHROPIC_API_KEY env var):
+       #   import anthropic
+       #   resp = anthropic.Anthropic().messages.create(
+       #       model="claude-sonnet-4-6", max_tokens=1024,
+       #       messages=[{"role": "user", "content": user_input}]
+       #   )
+       #   output_text = resp.content[0].text
+       #
+       # Google Gemini (pip install google-genai  — uses GOOGLE_API_KEY env var):
+       #   from google import genai
+       #   resp = genai.Client().models.generate_content(
+       #       model="gemini-2.5-pro", contents=user_input
+       #   )
+       #   output_text = resp.text
+
+       latency_ms = round((time.time() - start) * 1000)
+       runs.append({
+           "example_id": ex["id"],
+           "output": output_text,
+           "metadata": {"model": "MODEL_NAME", "latency_ms": latency_ms}
+       })
+       print(f"  {ex['id']}: {latency_ms}ms", file=sys.stderr)
+
+   json.dump(runs, sys.stdout, indent=2)
+   ```
+
+   **Before running:** install the provider SDK (`pip install openai` / `anthropic` / `google-genai`) and ensure the API key is set as an environment variable in your shell. If you cannot access the API, stop and tell the user what is needed.
+
+4. Verify the runs file:
+   ```bash
+   python3 -c "import json; runs=json.load(open('runs.json')); print(f'{len(runs)} runs'); print(json.dumps(runs[0], indent=2))"
+   ```
+   Each run must have `example_id` and `output`. Optional fields: `evaluations`, `metadata`.
 5. Create the experiment:
    ```bash
    ax experiments create --name "gpt-4o-baseline" --dataset DATASET_NAME --space SPACE --file runs.json

--- a/skills/arize-experiment/SKILL.md
+++ b/skills/arize-experiment/SKILL.md
@@ -282,6 +282,20 @@ At least one of `label`, `score`, or `explanation` should be present per evaluat
        #       model="gemini-2.5-pro", contents=user_input
        #   )
        #   output_text = resp.text
+       #
+       # Custom / OpenAI-compatible proxy (pip install openai — uses CUSTOM_BASE_URL + CUSTOM_API_KEY env vars):
+       # Use this for Azure OpenAI, NVIDIA NIM, local Ollama, or any OpenAI-compatible endpoint,
+       # including a test integration proxy. Matches the `custom` provider in `ax ai-integrations create`.
+       #   import os
+       #   from openai import OpenAI
+       #   resp = OpenAI(
+       #       base_url=os.environ["CUSTOM_BASE_URL"],          # e.g. https://my-proxy.example.com/v1
+       #       api_key=os.environ.get("CUSTOM_API_KEY", "none"),
+       #   ).chat.completions.create(
+       #       model=os.environ.get("CUSTOM_MODEL", "default"),
+       #       messages=[{"role": "user", "content": user_input}]
+       #   )
+       #   output_text = resp.choices[0].message.content
 
        latency_ms = round((time.time() - start) * 1000)
        runs.append({

--- a/skills/arize-instrumentation/SKILL.md
+++ b/skills/arize-instrumentation/SKILL.md
@@ -104,7 +104,7 @@ Proceed **only after the user confirms** the Phase 1 analysis.
    - Python: `pip install arize-otel` plus `openinference-instrumentation-{name}` (hyphens in package name; underscores in import, e.g. `openinference.instrumentation.llama_index`).
    - TypeScript/JavaScript: `@opentelemetry/sdk-trace-node` plus the relevant `@arizeai/openinference-*` package.
    - Java: OpenTelemetry SDK plus `openinference-instrumentation-*` in pom.xml or build.gradle.
-3. **Credentials** — User needs an **Arize API Key** and **Space ID**. Check `.env` or existing `ax` profiles for `ARIZE_API_KEY` and `ARIZE_SPACE`:
+3. **Credentials** — User needs an **Arize API Key** and **Space ID**. Check existing `ax` profiles for `ARIZE_API_KEY` and `ARIZE_SPACE` — never read `.env` files:
    - Run `ax profiles show` to check for an existing profile.
    - If no profile exists, guide the user to run `ax profiles create` which provides an **interactive wizard** that walks through API key and space setup. See [CLI profiles docs](https://arize.com/docs/api-clients/cli/profiles) for details.
    - If the user needs to find their API key manually, direct them to **https://app.arize.com** and to navigate to the settings page (do not use organization-specific URLs with placeholder IDs — they won't resolve for new users).

--- a/skills/arize-prompt-optimization/SKILL.md
+++ b/skills/arize-prompt-optimization/SKILL.md
@@ -52,10 +52,11 @@ Proceed directly with the task — run the `ax` command you need. Do NOT check v
 
 If an `ax` command fails, troubleshoot based on the error:
 - `command not found` or version error → see references/ax-setup.md
-- `401 Unauthorized` / missing API key → run `ax profiles show` to inspect the current profile. If the profile is missing or the API key is wrong: check `.env` for `ARIZE_API_KEY` and use it to create/update the profile via references/ax-profiles.md. If `.env` has no key either, ask the user for their Arize API key (https://app.arize.com/admin > API Keys)
-- Space unknown → check `.env` for `ARIZE_SPACE` (name or ID), or run `ax spaces list` to pick by name, or ask the user
-- Project unclear → check `.env` for `ARIZE_DEFAULT_PROJECT`, or ask, or run `ax projects list -o json --limit 100` and present as selectable options
-- LLM provider call fails (missing OPENAI_API_KEY / ANTHROPIC_API_KEY) → check `.env`, load if present, otherwise ask the user
+- `401 Unauthorized` / missing API key → run `ax profiles show` to inspect the current profile. If the profile is missing or the API key is wrong, follow references/ax-profiles.md to create/update it. If the user doesn't have their key, direct them to https://app.arize.com/admin > API Keys
+- Space unknown → run `ax spaces list` to pick by name, or ask the user
+- Project unclear → ask the user, or run `ax projects list -o json --limit 100` and present as selectable options
+- LLM provider call fails (missing OPENAI_API_KEY / ANTHROPIC_API_KEY) → run `ax ai-integrations list --space SPACE` to check for platform-managed credentials. If none exist, ask the user to provide the key or create an integration via the **arize-ai-provider-integration** skill
+- **Security:** Never read `.env` files or search the filesystem for credentials. Use `ax profiles` for Arize credentials and `ax ai-integrations` for LLM provider keys. If credentials are not available through these channels, ask the user.
 
 ## Phase 1: Extract the Current Prompt
 

--- a/skills/arize-trace/SKILL.md
+++ b/skills/arize-trace/SKILL.md
@@ -33,8 +33,9 @@ Proceed directly with the task — run the `ax` command you need. Do NOT check v
 
 If an `ax` command fails, troubleshoot based on the error:
 - `command not found` or version error → see references/ax-setup.md
-- `401 Unauthorized` / missing API key → run `ax profiles show` to inspect the current profile. If the profile is missing or the API key is wrong: check `.env` for `ARIZE_API_KEY` and use it to create/update the profile via references/ax-profiles.md. If `.env` has no key either, ask the user for their Arize API key (https://app.arize.com/admin > API Keys)
-- Space unknown → check `.env` for `ARIZE_SPACE` (name or ID), or run `ax spaces list` to pick by name, or ask the user
+- `401 Unauthorized` / missing API key → run `ax profiles show` to inspect the current profile. If the profile is missing or the API key is wrong, follow references/ax-profiles.md to create/update it. If the user doesn't have their key, direct them to https://app.arize.com/admin > API Keys
+- Space unknown → run `ax spaces list` to pick by name, or ask the user
+- **Security:** Never read `.env` files or search the filesystem for credentials. Use `ax profiles` for Arize credentials and `ax ai-integrations` for LLM provider keys. If credentials are not available through these channels, ask the user.
 - Project unclear → run `ax projects list -l 100 -o json` (add `--space SPACE` if known), present the names, and ask the user to pick one
 
 **IMPORTANT:** For `ax traces export`, `--space` is required when using a project name. For `ax spans export`, `--space` is only required when using `--all` (Arrow Flight). If you hit `401 Unauthorized` or limit errors, resolve the project name to a base64 ID first (see "Resolving project for export" in Concepts).


### PR DESCRIPTION
## Summary

- **Remove `.env` credential reads from all 8 skills** — replaced with `ax profiles` for Arize credentials and `ax ai-integrations` for LLM provider keys. Added a `Security:` rule bullet to each skill's Prerequisites section.
- **Anti-fabrication guardrails** — added `CRITICAL` bullets to `arize-evaluator` and `arize-experiment` skills explicitly forbidding the agent from inventing evaluation scores or model outputs when things fail.
- **Cancelled-run diagnostic checklist** — added a 6-step "Diagnosing cancelled runs" section to `arize-evaluator` covering credentials, model name, column path verification, epoch timestamps, span kind alignment, and template variable resolution.
- **Real inference workflow for experiments** — replaced the single-sentence step 3 in `arize-experiment` with an ax-CLI-first approach (`ax datasets export --stdout | python3 infer.py > runs.json`) plus a minimal inference script template with OpenAI, Anthropic, and Gemini SDK examples.