### PR TITLE
docs: fix --space flag documentation gaps

### DIFF
--- a/skills/arize-ai-provider-integration/SKILL.md
+++ b/skills/arize-ai-provider-integration/SKILL.md
@@ -5,7 +5,8 @@ description: "INVOKE THIS SKILL when creating, reading, updating, or deleting Ar
 
 # Arize AI Integration Skill
 
-> **`SPACE`** — All `--space` flags and the `ARIZE_SPACE` env var accept a space **name** (e.g., `my-workspace`) or a base64 space **ID** (e.g., `U3BhY2U6...`). Find yours with `ax spaces list`.
+> **`SPACE`** — Most `--space` flags and the `ARIZE_SPACE` env var accept a space **name** (e.g., `my-workspace`) or a base64 space **ID** (e.g., `U3BhY2U6...`). Find yours with `ax spaces list`.
+> **Note:** `ai-integrations create` does **not** accept `--space` — AI integrations are account-scoped. Use `--space` only with `list`, `get`, `update`, and `delete`.
 
 ## Concepts
 

--- a/skills/arize-ai-provider-integration/references/ax-setup.md
+++ b/skills/arize-ai-provider-integration/references/ax-setup.md
@@ -4,7 +4,7 @@ Consult this only when an `ax` command fails. Do NOT run these checks proactivel
 
 ## Check version first
 
-If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.12.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
+If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.14.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
 
 ## `ax: command not found`
 
@@ -19,7 +19,7 @@ If `ax` is installed (not `command not found`), always run `ax --version` before
 3. Install: `pip install arize-ax-cli`
 4. Add to PATH: `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
 
-## Version too old (below 0.12.0)
+## Version too old (below 0.14.0)
 
 Upgrade: `uv tool install --force --reinstall arize-ax-cli`, `pipx upgrade arize-ax-cli`, or `pip install --upgrade arize-ax-cli`
 

--- a/skills/arize-annotation/references/ax-setup.md
+++ b/skills/arize-annotation/references/ax-setup.md
@@ -4,7 +4,7 @@ Consult this only when an `ax` command fails. Do NOT run these checks proactivel
 
 ## Check version first
 
-If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.12.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
+If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.14.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
 
 ## `ax: command not found`
 
@@ -19,7 +19,7 @@ If `ax` is installed (not `command not found`), always run `ax --version` before
 3. Install: `pip install arize-ax-cli`
 4. Add to PATH: `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
 
-## Version too old (below 0.12.0)
+## Version too old (below 0.14.0)
 
 Upgrade: `uv tool install --force --reinstall arize-ax-cli`, `pipx upgrade arize-ax-cli`, or `pip install --upgrade arize-ax-cli`
 

--- a/skills/arize-dataset/references/ax-setup.md
+++ b/skills/arize-dataset/references/ax-setup.md
@@ -4,7 +4,7 @@ Consult this only when an `ax` command fails. Do NOT run these checks proactivel
 
 ## Check version first
 
-If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.12.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
+If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.14.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
 
 ## `ax: command not found`
 
@@ -19,7 +19,7 @@ If `ax` is installed (not `command not found`), always run `ax --version` before
 3. Install: `pip install arize-ax-cli`
 4. Add to PATH: `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
 
-## Version too old (below 0.12.0)
+## Version too old (below 0.14.0)
 
 Upgrade: `uv tool install --force --reinstall arize-ax-cli`, `pipx upgrade arize-ax-cli`, or `pip install --upgrade arize-ax-cli`
 

--- a/skills/arize-evaluator/references/ax-setup.md
+++ b/skills/arize-evaluator/references/ax-setup.md
@@ -4,7 +4,7 @@ Consult this only when an `ax` command fails. Do NOT run these checks proactivel
 
 ## Check version first
 
-If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.12.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
+If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.14.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
 
 ## `ax: command not found`
 
@@ -19,7 +19,7 @@ If `ax` is installed (not `command not found`), always run `ax --version` before
 3. Install: `pip install arize-ax-cli`
 4. Add to PATH: `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
 
-## Version too old (below 0.12.0)
+## Version too old (below 0.14.0)
 
 Upgrade: `uv tool install --force --reinstall arize-ax-cli`, `pipx upgrade arize-ax-cli`, or `pip install --upgrade arize-ax-cli`
 

--- a/skills/arize-experiment/SKILL.md
+++ b/skills/arize-experiment/SKILL.md
@@ -145,6 +145,7 @@ ax experiments create --name "claude-test" --dataset DATASET_NAME --space SPACE 
 |------|------|----------|-------------|
 | `--name, -n` | string | yes | Experiment name |
 | `--dataset` | string | yes | Dataset to run the experiment against |
+| `--space, -s` | string | no | Space name or ID (required if using dataset name instead of ID) |
 | `--file, -f` | path | yes | Data file with runs: CSV, JSON, JSONL, or Parquet |
 | `-o, --output` | string | no | Output format |
 | `-p, --profile` | string | no | Configuration profile |

--- a/skills/arize-experiment/references/ax-setup.md
+++ b/skills/arize-experiment/references/ax-setup.md
@@ -4,7 +4,7 @@ Consult this only when an `ax` command fails. Do NOT run these checks proactivel
 
 ## Check version first
 
-If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.12.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
+If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.14.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
 
 ## `ax: command not found`
 
@@ -19,7 +19,7 @@ If `ax` is installed (not `command not found`), always run `ax --version` before
 3. Install: `pip install arize-ax-cli`
 4. Add to PATH: `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
 
-## Version too old (below 0.12.0)
+## Version too old (below 0.14.0)
 
 Upgrade: `uv tool install --force --reinstall arize-ax-cli`, `pipx upgrade arize-ax-cli`, or `pip install --upgrade arize-ax-cli`
 

--- a/skills/arize-prompt-optimization/references/ax-setup.md
+++ b/skills/arize-prompt-optimization/references/ax-setup.md
@@ -4,7 +4,7 @@ Consult this only when an `ax` command fails. Do NOT run these checks proactivel
 
 ## Check version first
 
-If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.12.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
+If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.14.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
 
 ## `ax: command not found`
 
@@ -19,7 +19,7 @@ If `ax` is installed (not `command not found`), always run `ax --version` before
 3. Install: `pip install arize-ax-cli`
 4. Add to PATH: `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
 
-## Version too old (below 0.12.0)
+## Version too old (below 0.14.0)
 
 Upgrade: `uv tool install --force --reinstall arize-ax-cli`, `pipx upgrade arize-ax-cli`, or `pip install --upgrade arize-ax-cli`
 

--- a/skills/arize-trace/references/ax-setup.md
+++ b/skills/arize-trace/references/ax-setup.md
@@ -4,7 +4,7 @@ Consult this only when an `ax` command fails. Do NOT run these checks proactivel
 
 ## Check version first
 
-If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.12.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
+If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.14.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
 
 ## `ax: command not found`
 
@@ -19,7 +19,7 @@ If `ax` is installed (not `command not found`), always run `ax --version` before
 3. Install: `pip install arize-ax-cli`
 4. Add to PATH: `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
 
-## Version too old (below 0.12.0)
+## Version too old (below 0.14.0)
 
 Upgrade: `uv tool install --force --reinstall arize-ax-cli`, `pipx upgrade arize-ax-cli`, or `pip install --upgrade arize-ax-cli`
 


### PR DESCRIPTION
## Summary

- **arize-experiment**: add `--space` / `-s` to the `experiments create` flag table. It was shown in examples but missing from the table — and the CLI was previously rejecting it (fixed in [arize CLI PR #68887](https://github.com/Arize-ai/arize/pull/68887))
- **arize-ai-provider-integration**: clarify that `ai-integrations create` does **not** accept `--space` (AI integrations are account-scoped). The "All `--space` flags..." banner was causing agents to pass `--space` to `create`, which rejects it