### PR TITLE
chore: update skill frontmatter to latest Agent Skills spec

### DIFF
--- a/skills/arize-ai-provider-integration/SKILL.md
+++ b/skills/arize-ai-provider-integration/SKILL.md
@@ -1,11 +1,10 @@
 ---
 name: arize-ai-provider-integration
-description: Creates, reads, updates, and deletes Arize AI integrations for LLM providers (OpenAI, Anthropic, Azure OpenAI, AWS Bedrock, Vertex AI, Gemini, NVIDIA NIM, custom). Manages stored LLM provider credentials used by evaluators and other Arize features.
-when_to_use: "Use when the user mentions: AI integration, LLM provider, API key management, create integration, list integrations, update credentials, delete integration, provider setup, OpenAI integration, Anthropic integration, Azure OpenAI, AWS Bedrock, Vertex AI, Gemini, NVIDIA NIM."
+description: Creates, reads, updates, and deletes Arize AI integrations for LLM providers (OpenAI, Anthropic, Azure OpenAI, AWS Bedrock, Vertex AI, Gemini, NVIDIA NIM, custom). Manages stored LLM provider credentials used by evaluators and other Arize features. Use when the user mentions AI integration, LLM provider, API key management, create integration, list integrations, update credentials, delete integration, or provider setup.
 metadata:
   author: arize
   version: "1.0"
-compatibility: Requires the ax CLI (pip install arize-ax) and a configured Arize profile.
+compatibility: Requires the ax CLI and a configured Arize profile.
 ---
 
 # Arize AI Integration Skill

--- a/skills/arize-ai-provider-integration/SKILL.md
+++ b/skills/arize-ai-provider-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arize-ai-provider-integration
-description: Creates, reads, updates, and deletes Arize AI integrations that store LLM provider credentials used by evaluators and other Arize features. Use when the user mentions AI integration, LLM provider credentials, create integration, list integrations, update credentials, delete integration, or connecting an LLM provider to Arize.
+description: Creates, reads, updates, and deletes Arize AI integrations that store LLM provider credentials used by evaluators and other Arize features. Supports any LLM provider (e.g. OpenAI, Anthropic, Azure OpenAI, AWS Bedrock, Vertex AI, Gemini, NVIDIA NIM). Use when the user mentions AI integration, LLM provider credentials, create integration, list integrations, update credentials, delete integration, or connecting an LLM provider to Arize.
 metadata:
   author: arize
   version: "1.0"

--- a/skills/arize-ai-provider-integration/SKILL.md
+++ b/skills/arize-ai-provider-integration/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arize-ai-provider-integration
-description: Creates, reads, updates, and deletes Arize AI integrations for LLM providers (OpenAI, Anthropic, Azure OpenAI, AWS Bedrock, Vertex AI, Gemini, NVIDIA NIM, custom). Manages stored LLM provider credentials used by evaluators and other Arize features. Use when the user mentions AI integration, LLM provider, API key management, create integration, list integrations, update credentials, delete integration, or provider setup.
+description: Creates, reads, updates, and deletes Arize AI integrations that store LLM provider credentials used by evaluators and other Arize features. Use when the user mentions AI integration, LLM provider credentials, create integration, list integrations, update credentials, delete integration, or connecting an LLM provider to Arize.
 metadata:
   author: arize
   version: "1.0"

--- a/skills/arize-ai-provider-integration/SKILL.md
+++ b/skills/arize-ai-provider-integration/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: arize-ai-provider-integration
-description: "INVOKE THIS SKILL when creating, reading, updating, or deleting Arize AI integrations. Covers listing integrations, creating integrations for any supported LLM provider (OpenAI, Anthropic, Azure OpenAI, AWS Bedrock, Vertex AI, Gemini, NVIDIA NIM, custom), updating credentials or metadata, and deleting integrations using the ax CLI."
+description: Creates, reads, updates, and deletes Arize AI integrations for LLM providers (OpenAI, Anthropic, Azure OpenAI, AWS Bedrock, Vertex AI, Gemini, NVIDIA NIM, custom). Manages stored LLM provider credentials used by evaluators and other Arize features.
+when_to_use: "Use when the user mentions: AI integration, LLM provider, API key management, create integration, list integrations, update credentials, delete integration, provider setup, OpenAI integration, Anthropic integration, Azure OpenAI, AWS Bedrock, Vertex AI, Gemini, NVIDIA NIM."
+metadata:
+  author: arize
+  version: "1.0"
+compatibility: Requires the ax CLI (pip install arize-ax) and a configured Arize profile.
 ---
 
 # Arize AI Integration Skill

--- a/skills/arize-annotation/SKILL.md
+++ b/skills/arize-annotation/SKILL.md
@@ -1,11 +1,10 @@
 ---
 name: arize-annotation
-description: Creates and manages annotation configs (categorical, continuous, freeform label schemas) and annotation queues (human review workflows) on Arize. Applies human annotations to project spans via the Python SDK.
-when_to_use: "Use when the user mentions: annotation config, annotation queue, label schema, human feedback, bulk annotate spans, update_annotations, labeling queue, annotate record, categorical labels, continuous scores, freeform annotations, human review."
+description: Creates and manages annotation configs (categorical, continuous, freeform label schemas) and annotation queues (human review workflows) on Arize. Applies human annotations to project spans via the Python SDK. Use when the user mentions annotation config, annotation queue, label schema, human feedback, bulk annotate spans, update_annotations, labeling queue, annotate record, or human review.
 metadata:
   author: arize
   version: "1.0"
-compatibility: Requires the ax CLI (pip install arize-ax) and a configured Arize profile.
+compatibility: Requires the ax CLI and a configured Arize profile.
 ---
 
 # Arize Annotation Skill

--- a/skills/arize-annotation/SKILL.md
+++ b/skills/arize-annotation/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: arize-annotation
-description: "INVOKE THIS SKILL when creating, managing, or using annotation configs or annotation queues on Arize (categorical, continuous, freeform), or applying human annotations to project spans via the Python SDK. Configs are the label schema for human feedback; queues are review workflows that route records to annotators. Triggers: annotation config, annotation queue, label schema, human feedback schema, bulk annotate spans, update_annotations, labeling queue, annotate record."
+description: Creates and manages annotation configs (categorical, continuous, freeform label schemas) and annotation queues (human review workflows) on Arize. Applies human annotations to project spans via the Python SDK.
+when_to_use: "Use when the user mentions: annotation config, annotation queue, label schema, human feedback, bulk annotate spans, update_annotations, labeling queue, annotate record, categorical labels, continuous scores, freeform annotations, human review."
+metadata:
+  author: arize
+  version: "1.0"
+compatibility: Requires the ax CLI (pip install arize-ax) and a configured Arize profile.
 ---
 
 # Arize Annotation Skill

--- a/skills/arize-dataset/SKILL.md
+++ b/skills/arize-dataset/SKILL.md
@@ -1,11 +1,10 @@
 ---
 name: arize-dataset
-description: Creates, manages, and queries Arize datasets and examples. Covers dataset CRUD, appending examples, exporting data, and file-based dataset creation using the ax CLI.
-when_to_use: "Use when the user needs test data, evaluation examples, or mentions: create dataset, list datasets, export dataset, append examples, dataset version, upload data, evaluation data, golden dataset, test set."
+description: Creates, manages, and queries Arize datasets and examples. Covers dataset CRUD, appending examples, exporting data, and file-based dataset creation using the ax CLI. Use when the user needs test data, evaluation examples, or mentions create dataset, list datasets, export dataset, append examples, dataset version, golden dataset, or test set.
 metadata:
   author: arize
   version: "1.0"
-compatibility: Requires the ax CLI (pip install arize-ax) and a configured Arize profile.
+compatibility: Requires the ax CLI and a configured Arize profile.
 ---
 
 # Arize Dataset Skill

--- a/skills/arize-dataset/SKILL.md
+++ b/skills/arize-dataset/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: arize-dataset
-description: "INVOKE THIS SKILL when creating, managing, or querying Arize datasets and examples. Also use when the user needs test data or evaluation examples for their model. Covers dataset CRUD, appending examples, exporting data, and file-based dataset creation using the ax CLI."
+description: Creates, manages, and queries Arize datasets and examples. Covers dataset CRUD, appending examples, exporting data, and file-based dataset creation using the ax CLI.
+when_to_use: "Use when the user needs test data, evaluation examples, or mentions: create dataset, list datasets, export dataset, append examples, dataset version, upload data, evaluation data, golden dataset, test set."
+metadata:
+  author: arize
+  version: "1.0"
+compatibility: Requires the ax CLI (pip install arize-ax) and a configured Arize profile.
 ---
 
 # Arize Dataset Skill

--- a/skills/arize-evaluator/SKILL.md
+++ b/skills/arize-evaluator/SKILL.md
@@ -1,11 +1,10 @@
 ---
 name: arize-evaluator
-description: Handles LLM-as-judge evaluation workflows on Arize including creating/updating evaluators, running evaluations on spans or experiments, managing tasks, trigger-run operations, column mapping, and continuous monitoring.
-when_to_use: "Use when the user mentions: create evaluator, LLM judge, hallucination, faithfulness, correctness, relevance, run eval, score spans, score experiment, ax tasks, trigger-run, trigger eval, column mapping, continuous monitoring, query filter for evals, evaluator version, improve evaluator prompt."
+description: Handles LLM-as-judge evaluation workflows on Arize including creating/updating evaluators, running evaluations on spans or experiments, managing tasks, trigger-run operations, column mapping, and continuous monitoring. Use when the user mentions create evaluator, LLM judge, hallucination, faithfulness, correctness, relevance, run eval, score spans, score experiment, trigger-run, column mapping, continuous monitoring, or improve evaluator prompt.
 metadata:
   author: arize
   version: "1.0"
-compatibility: Requires the ax CLI (pip install arize-ax) and a configured Arize profile with an AI integration.
+compatibility: Requires the ax CLI and a configured Arize profile with an AI integration.
 ---
 
 # Arize Evaluator Skill

--- a/skills/arize-evaluator/SKILL.md
+++ b/skills/arize-evaluator/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: arize-evaluator
-description: "INVOKE THIS SKILL for LLM-as-judge evaluation workflows on Arize: creating/updating evaluators, running evaluations on spans or experiments, tasks, trigger-run, column mapping, and continuous monitoring. Use when the user says: create an evaluator, LLM judge, hallucination/faithfulness/correctness/relevance, run eval, score my spans or experiment, ax tasks, trigger-run, trigger eval, column mapping, continuous monitoring, query filter for evals, evaluator version, or improve an evaluator prompt."
+description: Handles LLM-as-judge evaluation workflows on Arize including creating/updating evaluators, running evaluations on spans or experiments, managing tasks, trigger-run operations, column mapping, and continuous monitoring.
+when_to_use: "Use when the user mentions: create evaluator, LLM judge, hallucination, faithfulness, correctness, relevance, run eval, score spans, score experiment, ax tasks, trigger-run, trigger eval, column mapping, continuous monitoring, query filter for evals, evaluator version, improve evaluator prompt."
+metadata:
+  author: arize
+  version: "1.0"
+compatibility: Requires the ax CLI (pip install arize-ax) and a configured Arize profile with an AI integration.
 ---
 
 # Arize Evaluator Skill

--- a/skills/arize-experiment/SKILL.md
+++ b/skills/arize-experiment/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: arize-experiment
-description: "INVOKE THIS SKILL when creating, running, or analyzing Arize experiments. Also use when the user wants to evaluate or measure model performance, compare models (including GPT-4, Claude, or others), or assess how well their AI is doing. Covers experiment CRUD, exporting runs, comparing results, and evaluation workflows using the ax CLI."
+description: Creates, runs, and analyzes Arize experiments for evaluating and comparing model performance. Covers experiment CRUD, exporting runs, comparing results, and evaluation workflows using the ax CLI.
+when_to_use: "Use when the user mentions: create experiment, run experiment, compare models, model performance, evaluate AI, GPT-4 vs Claude, experiment results, export runs, benchmark, A/B test models, measure accuracy."
+metadata:
+  author: arize
+  version: "1.0"
+compatibility: Requires the ax CLI (pip install arize-ax) and a configured Arize profile.
 ---
 
 # Arize Experiment Skill

--- a/skills/arize-experiment/SKILL.md
+++ b/skills/arize-experiment/SKILL.md
@@ -1,11 +1,10 @@
 ---
 name: arize-experiment
-description: Creates, runs, and analyzes Arize experiments for evaluating and comparing model performance. Covers experiment CRUD, exporting runs, comparing results, and evaluation workflows using the ax CLI.
-when_to_use: "Use when the user mentions: create experiment, run experiment, compare models, model performance, evaluate AI, GPT-4 vs Claude, experiment results, export runs, benchmark, A/B test models, measure accuracy."
+description: Creates, runs, and analyzes Arize experiments for evaluating and comparing model performance. Covers experiment CRUD, exporting runs, comparing results, and evaluation workflows using the ax CLI. Use when the user mentions create experiment, run experiment, compare models, model performance, evaluate AI, experiment results, benchmark, A/B test models, or measure accuracy.
 metadata:
   author: arize
   version: "1.0"
-compatibility: Requires the ax CLI (pip install arize-ax) and a configured Arize profile.
+compatibility: Requires the ax CLI and a configured Arize profile.
 ---
 
 # Arize Experiment Skill

--- a/skills/arize-instrumentation/SKILL.md
+++ b/skills/arize-instrumentation/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: arize-instrumentation
-description: Adds Arize AX tracing and observability to LLM applications. Follows a two-phase agent-assisted flow to analyze the codebase then implement tracing after user confirmation. Handles manual CHAIN and TOOL spans for function calling.
-when_to_use: "Use when the user mentions: instrument app, add tracing, set up observability, OpenTelemetry, openinference, LLM observability, trace my app, get started with Arize, add spans, instrument LLM, monitor AI app."
+description: Adds Arize AX tracing and observability to LLM applications. Follows a two-phase agent-assisted flow to analyze the codebase then implement tracing after user confirmation. Handles manual CHAIN and TOOL spans for function calling. Use when the user mentions instrument app, add tracing, set up observability, OpenTelemetry, openinference, LLM observability, trace my app, get started with Arize, or monitor AI app.
 metadata:
   author: arize
   version: "1.0"

--- a/skills/arize-instrumentation/SKILL.md
+++ b/skills/arize-instrumentation/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: arize-instrumentation
-description: "INVOKE THIS SKILL when adding Arize AX tracing or observability to an app for the first time, or when the user wants to instrument their LLM app or get started with LLM observability. Follow the Agent-Assisted Tracing two-phase flow: analyze the codebase (read-only), then implement after user confirmation. When the app uses LLM tool/function calling, add manual CHAIN + TOOL spans. Leverages https://arize.com/docs/ax/alyx/tracing-assistant and https://arize.com/docs/PROMPT.md."
+description: Adds Arize AX tracing and observability to LLM applications. Follows a two-phase agent-assisted flow to analyze the codebase then implement tracing after user confirmation. Handles manual CHAIN and TOOL spans for function calling.
+when_to_use: "Use when the user mentions: instrument app, add tracing, set up observability, OpenTelemetry, openinference, LLM observability, trace my app, get started with Arize, add spans, instrument LLM, monitor AI app."
+metadata:
+  author: arize
+  version: "1.0"
+compatibility: Requires Python with openinference-instrumentation packages. See https://arize.com/docs/PROMPT.md for setup details.
 ---
 
 # Arize Instrumentation Skill

--- a/skills/arize-instrumentation/SKILL.md
+++ b/skills/arize-instrumentation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arize-instrumentation
-description: Adds Arize AX tracing and observability to LLM applications. Follows a two-phase agent-assisted flow to analyze the codebase then implement tracing after user confirmation. Handles manual CHAIN and TOOL spans for function calling. Use when the user mentions instrument app, add tracing, set up observability, OpenTelemetry, openinference, LLM observability, trace my app, get started with Arize, or monitor AI app.
+description: Adds Arize AX tracing to an LLM application for the first time. Follows a two-phase agent-assisted flow to analyze the codebase then implement instrumentation after user confirmation. Use when the user wants to instrument their app, add tracing from scratch, set up LLM observability, integrate OpenTelemetry or openinference, or get started with Arize tracing.
 metadata:
   author: arize
   version: "1.0"

--- a/skills/arize-link/SKILL.md
+++ b/skills/arize-link/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: arize-link
-description: Generates deep links to the Arize UI for traces, spans, sessions, datasets, labeling queues, evaluators, and annotation configs. Produces clickable URLs for sharing Arize resources with team members.
-when_to_use: "Use when the user mentions: link to trace, open in Arize, share trace, view span, session URL, dataset link, evaluator link, annotation config link, Arize URL, open trace, view in UI."
+description: Generates deep links to the Arize UI for traces, spans, sessions, datasets, labeling queues, evaluators, and annotation configs. Produces clickable URLs for sharing Arize resources with team members. Use when the user wants to link to or open a trace, span, session, dataset, evaluator, or annotation config in the Arize UI.
 metadata:
   author: arize
   version: "1.0"

--- a/skills/arize-link/SKILL.md
+++ b/skills/arize-link/SKILL.md
@@ -1,6 +1,10 @@
 ---
 name: arize-link
-description: Generate deep links to the Arize UI. Use when the user wants a clickable URL to open or share a specific trace, span, session, dataset, labeling queue, evaluator, or annotation config, or when sharing Arize resources with team members.
+description: Generates deep links to the Arize UI for traces, spans, sessions, datasets, labeling queues, evaluators, and annotation configs. Produces clickable URLs for sharing Arize resources with team members.
+when_to_use: "Use when the user mentions: link to trace, open in Arize, share trace, view span, session URL, dataset link, evaluator link, annotation config link, Arize URL, open trace, view in UI."
+metadata:
+  author: arize
+  version: "1.0"
 ---
 
 # Arize Link

--- a/skills/arize-prompt-optimization/SKILL.md
+++ b/skills/arize-prompt-optimization/SKILL.md
@@ -1,11 +1,10 @@
 ---
 name: arize-prompt-optimization
-description: Optimizes, improves, and debugs LLM prompts using production trace data, evaluations, and annotations. Extracts prompts from spans, gathers performance signal, and runs a data-driven optimization loop using the ax CLI.
-when_to_use: "Use when the user mentions: optimize prompt, improve prompt, debug prompt, make AI respond better, improve output quality, prompt engineering, prompt tuning, bad LLM responses, prompt iteration, system prompt improvement."
+description: Optimizes, improves, and debugs LLM prompts using production trace data, evaluations, and annotations. Extracts prompts from spans, gathers performance signal, and runs a data-driven optimization loop using the ax CLI. Use when the user mentions optimize prompt, improve prompt, make AI respond better, improve output quality, prompt engineering, prompt tuning, or system prompt improvement.
 metadata:
   author: arize
   version: "1.0"
-compatibility: Requires the ax CLI (pip install arize-ax) and a configured Arize profile.
+compatibility: Requires the ax CLI and a configured Arize profile.
 ---
 
 # Arize Prompt Optimization Skill

--- a/skills/arize-prompt-optimization/SKILL.md
+++ b/skills/arize-prompt-optimization/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: arize-prompt-optimization
-description: "INVOKE THIS SKILL when optimizing, improving, or debugging LLM prompts using production trace data, evaluations, and annotations. Also use when the user wants to make their AI respond better or improve AI output quality. Covers extracting prompts from spans, gathering performance signal, and running a data-driven optimization loop using the ax CLI."
+description: Optimizes, improves, and debugs LLM prompts using production trace data, evaluations, and annotations. Extracts prompts from spans, gathers performance signal, and runs a data-driven optimization loop using the ax CLI.
+when_to_use: "Use when the user mentions: optimize prompt, improve prompt, debug prompt, make AI respond better, improve output quality, prompt engineering, prompt tuning, bad LLM responses, prompt iteration, system prompt improvement."
+metadata:
+  author: arize
+  version: "1.0"
+compatibility: Requires the ax CLI (pip install arize-ax) and a configured Arize profile.
 ---
 
 # Arize Prompt Optimization Skill

--- a/skills/arize-trace/SKILL.md
+++ b/skills/arize-trace/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: arize-trace
-description: "INVOKE THIS SKILL when downloading, exporting, or inspecting Arize traces and spans, or when a user wants to look at what their LLM app is doing using existing trace data, or when an already-instrumented app has a bug or error to investigate. Use for debugging unknown runtime issues, failures, and behavior regressions. Covers exporting traces by ID, spans by ID, sessions by ID, and root-cause investigation with the ax CLI."
+description: Downloads, exports, and inspects Arize traces and spans for debugging and analysis. Covers exporting traces by ID, spans by ID, sessions by ID, and root-cause investigation of runtime issues using the ax CLI.
+when_to_use: "Use when the user mentions: export traces, download spans, inspect trace, debug LLM app, view trace data, session export, runtime error investigation, behavior regression, span analysis, trace export, what is my app doing."
+metadata:
+  author: arize
+  version: "1.0"
+compatibility: Requires the ax CLI (pip install arize-ax) and a configured Arize profile.
 ---
 
 # Arize Trace Skill

--- a/skills/arize-trace/SKILL.md
+++ b/skills/arize-trace/SKILL.md
@@ -1,11 +1,10 @@
 ---
 name: arize-trace
-description: Downloads, exports, and inspects Arize traces and spans for debugging and analysis. Covers exporting traces by ID, spans by ID, sessions by ID, and root-cause investigation of runtime issues using the ax CLI.
-when_to_use: "Use when the user mentions: export traces, download spans, inspect trace, debug LLM app, view trace data, session export, runtime error investigation, behavior regression, span analysis, trace export, what is my app doing."
+description: Downloads, exports, and inspects Arize traces and spans for debugging and analysis. Covers exporting traces by ID, spans by ID, sessions by ID, and root-cause investigation of runtime issues using the ax CLI. Use when the user mentions export traces, download spans, inspect trace, debug LLM app, view trace data, session export, runtime error, behavior regression, or span analysis.
 metadata:
   author: arize
   version: "1.0"
-compatibility: Requires the ax CLI (pip install arize-ax) and a configured Arize profile.
+compatibility: Requires the ax CLI and a configured Arize profile.
 ---
 
 # Arize Trace Skill

--- a/skills/arize-trace/SKILL.md
+++ b/skills/arize-trace/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arize-trace
-description: Downloads, exports, and inspects Arize traces and spans for debugging and analysis. Covers exporting traces by ID, spans by ID, sessions by ID, and root-cause investigation of runtime issues using the ax CLI. Use when the user mentions export traces, download spans, inspect trace, debug LLM app, view trace data, session export, runtime error, behavior regression, or span analysis.
+description: Downloads, exports, and inspects existing Arize traces and spans to understand what an LLM app is doing or debug runtime issues. Covers exporting traces by ID, spans by ID, sessions by ID, and root-cause investigation using the ax CLI. Use when the user wants to look at existing trace data, see what their LLM app is doing, export traces, download spans, investigate errors, or analyze behavior regressions.
 metadata:
   author: arize
   version: "1.0"


### PR DESCRIPTION
## Summary
- Restructured YAML frontmatter across all 9 skills to align with the [Agent Skills open standard](https://agentskills.io/specification) and [Claude Code skill docs](https://code.claude.com/docs/en/skills)
- Split monolithic `description` fields into `description` (concise capability summary) + `when_to_use` (trigger keywords for discovery)
- Added `metadata` (author, version) and `compatibility` (environment requirements) fields to all skills