### PR TITLE
feat: add arize-admin skill

### DIFF
--- a/.github/workflows/skill-selection-tests.yml
+++ b/.github/workflows/skill-selection-tests.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: skill-selection-results
           path: tests/test-results/

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ For interactive setup, `ax profiles create` also offers **Advanced → Single en
 | [arize-prompt-optimization](skills/arize-prompt-optimization/SKILL.md) | Optimize prompts using trace data, experiments, and meta-prompting. |
 | [arize-link](skills/arize-link/SKILL.md) | Generate deep links to traces, spans, and sessions in the Arize UI. |
 | [arize-compliance-audit](skills/arize-compliance-audit/SKILL.md) | Audit an AI agent for regulatory compliance (EU AI Act, NIST AI RMF, GDPR, HIPAA). Produces a tailored remediation checklist. |
+| [arize-admin](skills/arize-admin/SKILL.md) | Manage organizations, spaces, roles, role bindings, resource restrictions, and API keys. Enterprise admin workflows: team onboarding, SAML/SSO role mapping, service key management, and access control. |
 
 > [!WARNING]
 > **arize-compliance-audit is for guidance only and does not constitute legal advice or a complete compliance assessment.** It identifies common technical patterns based on publicly available regulatory frameworks and cannot account for your organisation's specific legal obligations, contractual commitments, or operational context. Always consult a qualified attorney or compliance specialist for binding assessments.

--- a/skills/arize-admin/SKILL.md
+++ b/skills/arize-admin/SKILL.md
@@ -29,7 +29,7 @@ Programmatic management of Arize users, organizations, spaces, roles, permission
 - **Space** — a workspace that isolates traces, datasets, and projects. A user must be an org member before they can be added to a space within that org.
 - **Role** — a named set of permissions. Predefined roles are system-managed. Custom roles are created by admins. The roles for org/space membership (`admin`, `member`, `read-only`, `annotator`) are separate from custom RBAC roles used with `ax role-bindings`.
 - **Role binding** — fine-grained assignment of a custom role to a user on a specific resource (a space or a project).
-- **Resource restriction** — marks a project so that only users with an explicit role binding on that project can access it. Space-level roles are excluded.
+- **Resource restriction** — marks a project so that only users with an explicit role binding on that project can access it. Roles bound at any higher hierarchy level (space, org, account) are excluded.
 - **API key** — either a *user* key (authenticates as the creator, full user permissions) or a *service* key (scoped to a specific space, for automated pipelines).
 
 ## Prerequisites

--- a/skills/arize-admin/SKILL.md
+++ b/skills/arize-admin/SKILL.md
@@ -30,6 +30,33 @@ Programmatic management of Arize users, organizations, spaces, roles, permission
 - Create scoped service keys for CI/CD pipelines or multi-tenant architectures
 - Rotate or revoke API keys
 
+## Upfront Questions
+
+For multi-step workflows, **collect all required information before running any `ax` commands**. Use `AskUserQuestion` to avoid back-and-forth mid-workflow. Fetch live data first (e.g. org list) so you can present real options rather than asking the user to recall IDs.
+
+### Onboarding a new team
+1. Run `ax organizations list -o json` to get available org names.
+2. Use `AskUserQuestion` (single call, up to 4 questions) to gather:
+   - **Which org?** — present the org names from the list as options
+   - **Space name** — what to call the new team's space
+   - **Team members** — names and emails to invite (user can type via "Other"; ask if none yet)
+   - **Service key?** — whether to generate a service key for CI/CD pipelines
+
+### Offboarding a user
+Ask before running any commands:
+- **Which user?** — email address (then look up with `ax users list --email`)
+
+### Restricting a project
+Ask before running any commands:
+- **Which space and project?** — to look up the project global ID
+- **Which users get explicit access?** — emails of users to bind to the restricted project
+
+### Inviting users (standalone)
+Ask before running any commands:
+- **Name and email** — for each user to invite
+- **Role** — `admin`, `member`, or `read-only` (present as options)
+- **Invite mode** — `email_link` (default), `temporary_password`, or `none`
+
 ## Concepts
 
 - **Organization** — a named grouping within an account (e.g. one per business unit). Spaces live inside organizations. Users are added to the account first, then to orgs, then to spaces.

--- a/skills/arize-admin/SKILL.md
+++ b/skills/arize-admin/SKILL.md
@@ -11,7 +11,7 @@ compatibility: Requires the ax CLI (≥ 0.14.0) and a configured Arize profile w
 
 Programmatic management of Arize users, organizations, spaces, roles, permissions, and API keys — the building blocks for enterprise access control.
 
-> **Privilege requirement:** Most operations in this skill require **org-admin** or **account-admin** privileges. If commands return `403 Forbidden`, the authenticated profile does not have sufficient permissions.
+> **Privilege requirement:** Most operations require **org-admin** or **account-admin** privileges. If commands return `403 Forbidden`, the authenticated profile lacks sufficient permissions.
 
 ## When to Use
 
@@ -19,8 +19,6 @@ Programmatic management of Arize users, organizations, spaces, roles, permission
 - Offboard a user and revoke all their access in one command
 - Onboard a new team: create a space, create a custom role, assign users, generate a service key
 - Create custom roles for SAML/SSO attribute mappings (need stable role IDs)
-- List roles and their IDs to configure an IdP
-- Assign or change a user's role in a space or on a project
 - Restrict a project so only explicitly bound users can access it
 - Create scoped service keys for CI/CD pipelines or multi-tenant architectures
 - Rotate or revoke API keys
@@ -48,86 +46,29 @@ If an `ax` command fails:
 
 ## Users
 
-Manage account-level users. A user must exist in the account before they can be added to an org or space.
-
-**Account-level roles:** `admin`, `member`, `annotator`
-
-### List
+A user must exist in the account before they can be added to an org or space. **Account-level roles:** `admin`, `member`, `annotator`
 
 ```bash
 ax users list                                  # all users
-ax users list --email "jane"                   # substring filter on email
-ax users list --status active                  # active users only
-ax users list --status invited                 # pending invitations
+ax users list --email "jane"                   # substring filter
+ax users list --status active                  # active only
 ax users list -l 100 -o json                   # paginate, get global IDs
-```
 
-Use `ax users list -o json` to look up a user's global ID (base64) for use with `ax role-bindings`, `ax organizations add-user`, and `ax spaces add-user`.
+ax users get USER_ID
 
-### Get
-
-```bash
-ax users get USER_ID                           # by global base64 ID
-```
-
-### Create (invite)
-
-Creates the user account and optionally sends an invitation.
-
-```bash
-# Send an email invitation
 ax users create \
   --full-name "Jane Doe" \
   --email jane@example.com \
   --role member \
-  --invite-mode email_link
+  --invite-mode email_link        # or: none | temporary_password
 
-# Create without sending an invite (e.g. for SSO/JIT provisioning)
-ax users create \
-  --full-name "Jane Doe" \
-  --email jane@example.com \
-  --role member \
-  --invite-mode none
-
-# Send a temporary password instead of a link
-ax users create \
-  --full-name "Jane Doe" \
-  --email jane@example.com \
-  --role admin \
-  --invite-mode temporary_password
-```
-
-**Invite modes:**
-
-| Mode                 | Description                                      |
-|----------------------|--------------------------------------------------|
-| `none`               | Create the user without sending any invitation   |
-| `email_link`         | Send an invitation email with a sign-in link     |
-| `temporary_password` | Send an email with a one-time temporary password |
-
-### Update
-
-```bash
 ax users update USER_ID --full-name "Jane Smith"
 ax users update USER_ID --is-developer          # grant developer flag
-ax users update USER_ID --no-is-developer       # revoke developer flag
-```
 
-### Delete
+ax users delete USER_ID --force   # cascades: org/space memberships, API keys, role bindings
 
-Deletes the user and **cascades to all organization memberships, space memberships, API keys, and role bindings**. This is the primary offboarding command.
-
-```bash
-ax users delete USER_ID --force
-```
-
-Get `USER_ID` from `ax users list -o json`.
-
-### Re-invite / Reset password
-
-```bash
-ax users resend-invitation USER_ID    # resend invite to a pending user
-ax users reset-password USER_ID       # send a password-reset email
+ax users resend-invitation USER_ID
+ax users reset-password USER_ID
 ```
 
 ---
@@ -136,48 +77,21 @@ ax users reset-password USER_ID       # send a password-reset email
 
 **Organization roles:** `admin`, `member`, `read-only`, `annotator`
 
-### List
-
 ```bash
 ax organizations list
-ax organizations list --name "platform"        # substring filter
+ax organizations list --name "platform"
 ax organizations list -l 100 -o json
-```
 
-### Get
+ax organizations get "Platform Team"
 
-```bash
-ax organizations get "Platform Team"           # by name
-ax organizations get ORG_ID                    # by base64 ID
-```
-
-### Create
-
-```bash
 ax organizations create --name "Platform Team" --description "Core ML platform"
-```
 
-Names must be unique within the account.
+ax organizations update "Platform Team" --name "ML Platform" --description "Updated"
 
-### Update
-
-```bash
-ax organizations update "Platform Team" --name "ML Platform" --description "Updated desc"
-ax organizations update ORG_ID --description ""   # clear description
-```
-
-### Add / remove users
-
-Add a user to an org (or update their role if already a member). The user must exist in the account — create them first with `ax users create` if needed.
-
-```bash
+# Add user (must exist in account first)
 ax organizations add-user "Platform Team" --user-id USER_ID --role member
-ax organizations add-user "Platform Team" --user-id USER_ID --role admin
-```
 
-Remove a user from an org. **Also removes them from all child spaces within that org.**
-
-```bash
+# Remove user (also removes from all child spaces)
 ax organizations remove-user "Platform Team" --user-id USER_ID --force
 ```
 
@@ -187,57 +101,21 @@ ax organizations remove-user "Platform Team" --user-id USER_ID --force
 
 **Space roles:** `admin`, `member`, `read-only`, `annotator`
 
-### List
-
 ```bash
 ax spaces list
-ax spaces list --organization-id ORG_ID        # filter to one org
-ax spaces list -l 100 -o json
-```
+ax spaces list --organization-id ORG_ID
 
-### Get
-
-```bash
 ax spaces get "my-workspace"
-ax spaces get U3BhY2U6...                       # base64 ID
-```
 
-### Create
-
-`--organization-id` is required. Get the org ID from `ax organizations list -o json`.
-
-```bash
+# --organization-id required; get ORG_ID from ax organizations list -o json
 ax spaces create --name "team-alpha" --organization-id ORG_ID
-ax spaces create --name "team-alpha" --organization-id ORG_ID --description "Alpha team workspace"
-```
 
-### Update
-
-```bash
 ax spaces update "team-alpha" --name "team-alpha-v2"
-ax spaces update SPACE_ID --description "Updated description"
-```
 
-### Delete
+ax spaces delete "team-alpha" --force   # irreversible; deletes all resources
 
-Deletes the space **and all resources within it** (traces, datasets, projects, etc.). Irreversible.
-
-```bash
-ax spaces delete "team-alpha" --force       # --force skips confirmation
-```
-
-### Add / remove users
-
-The user must already be a member of the space's **parent organization** before they can be added to a space.
-
-```bash
+# User must be an org member before being added to a space
 ax spaces add-user "team-alpha" --user-id USER_ID --role member
-ax spaces add-user "team-alpha" --user-id USER_ID --role admin
-```
-
-Remove a user from a space (does not remove them from the parent org).
-
-```bash
 ax spaces remove-user "team-alpha" --user-id USER_ID --force
 ```
 
@@ -245,353 +123,108 @@ ax spaces remove-user "team-alpha" --user-id USER_ID --force
 
 ## Roles
 
-Custom RBAC roles used with `ax role-bindings` for fine-grained project/space access control. Separate from the simpler `admin`/`member`/`read-only`/`annotator` roles used in org and space membership.
-
-### List
+Custom RBAC roles used with `ax role-bindings`. Separate from the simpler `admin`/`member`/`read-only`/`annotator` roles in org/space membership.
 
 ```bash
-ax roles list                          # all roles (predefined + custom)
-ax roles list --is-predefined          # system roles only
-ax roles list --is-custom              # custom roles only
-ax roles list -l 100 -o json           # paginate — get IDs for SAML mappings
-```
+ax roles list                          # all roles
+ax roles list --is-custom -o json      # custom only — get stable IDs for SAML mappings
+ax roles list --is-predefined
 
-Use `--is-custom -o json` to retrieve stable role IDs for SAML attribute mapping in your IdP config.
+ax roles get "Data Scientist"          # inspect permissions
 
-### Get
-
-```bash
-ax roles get "Data Scientist"
-ax roles get ROLE_ID                   # by base64 ID
-```
-
-Returns the role's permissions list — inspect a predefined role to discover available permission names.
-
-### Create
-
-`--permissions` is comma-separated. At least one permission is required. Names must be unique within the account.
-
-```bash
+# --permissions is comma-separated; fully replaces on update
 ax roles create \
   --name "Data Scientist" \
   --permissions "PROJECT_READ,DATASET_CREATE,EXPERIMENT_CREATE" \
-  --description "Read traces, create datasets and experiments — no admin"
+  --description "Read traces, create datasets and experiments"
 
-ax roles create \
-  --name "Trace Writer" \
-  --permissions "PROJECT_READ,TRACE_CREATE" \
-  --description "Service accounts that send traces only"
-```
-
-**Finding available permissions:** Run `ax roles get <predefined-role> -o json` on a system role (e.g. `Member`, `Admin`) to see its full permission set — those names are valid for custom roles.
-
-### Update
-
-When `--permissions` is provided, it **fully replaces** the existing permission set (not additive).
-
-```bash
 ax roles update "Data Scientist" --permissions "PROJECT_READ,DATASET_CREATE,EXPERIMENT_CREATE,EVALUATOR_CREATE"
-ax roles update "Data Scientist" --name "ML Engineer" --description "Updated scope"
+
+ax roles delete "Data Scientist" --force   # predefined roles cannot be deleted
 ```
 
-Predefined (system) roles cannot be updated.
-
-### Delete
-
-```bash
-ax roles delete "Data Scientist" --force
-```
-
-Predefined roles cannot be deleted.
+**Finding available permissions:** Run `ax roles get <predefined-role> -o json` on a system role (e.g. `Member`, `Admin`) to see valid permission names.
 
 ---
 
 ## Role Bindings
 
-Fine-grained assignment of a custom role to a user on a specific resource (space or project). Use this when the simpler org/space membership roles (`admin`, `member`, etc.) aren't granular enough.
+Fine-grained assignment of a custom role to a user on a specific resource (space or project).
 
-> **No list command:** `ax role-bindings` does not have a `list` subcommand. To enumerate all bindings on a resource, use the Arize UI (Settings > Users & Permissions). You can only `get` a binding if you already know its ID.
-
-> **Getting user IDs:** Run `ax users list -o json` to get a user's global base64 ID for use with `--user-id`.
-
-### Create
+> **No list command.** To enumerate all bindings on a resource, use the Arize UI (Settings > Users & Permissions).
 
 ```bash
-# Assign a role at the space level
+# Assign at space level
 ax role-bindings create \
   --user-id USER_GLOBAL_ID \
   --role-id ROLE_GLOBAL_ID \
   --resource-type SPACE \
   --resource-id SPACE_GLOBAL_ID
 
-# Assign a role at the project level (for fine-grained access)
+# Assign at project level
 ax role-bindings create \
   --user-id USER_GLOBAL_ID \
   --role-id ROLE_GLOBAL_ID \
   --resource-type PROJECT \
   --resource-id PROJECT_GLOBAL_ID
-```
 
-Idempotent — if a binding already exists for the user on that resource, the command exits without error.
-
-### Get
-
-```bash
 ax role-bindings get BINDING_ID
-```
-
-### Update (change the assigned role)
-
-```bash
 ax role-bindings update BINDING_ID --role-id NEW_ROLE_ID
-```
-
-### Delete (revoke access)
-
-```bash
 ax role-bindings delete BINDING_ID --force
 ```
+
+Idempotent — if a binding already exists for the user on that resource, exits without error.
 
 ---
 
 ## Resource Restrictions
 
-Restricts a **project** so that only users with an explicit role binding on that project can access it. Roles bound at the space, org, or account level are excluded from that project.
-
-Currently only `PROJECT` resources are supported.
-
-### Restrict a project
+Restricts a **project** so only users with an explicit role binding on that project can access it. Space/org-level roles are excluded.
 
 ```bash
-ax resource-restrictions restrict --resource-id PROJECT_GLOBAL_ID
-```
-
-Idempotent — safe to run even if already restricted.
-
-### Unrestrict a project
-
-Removes the restriction so space-level roles apply again.
-
-```bash
+ax resource-restrictions restrict --resource-id PROJECT_GLOBAL_ID     # idempotent
 ax resource-restrictions unrestrict --resource-id PROJECT_GLOBAL_ID --force
-```
 
-### Finding project IDs
-
-```bash
+# Finding project IDs
 ax projects list -l 100 -o json --space "my-workspace"
 ```
-
-Use the `id` field (base64) as `--resource-id`.
 
 ---
 
 ## API Keys
 
-> **Scope:** `ax api-keys list` returns only keys owned by the **authenticated user**. There is no CLI command to list or revoke another user's keys. For org-wide key auditing, use the Arize UI (Settings > API Keys).
-
-### List
+> **Scope:** `ax api-keys list` returns only keys owned by the **authenticated user**. For org-wide auditing, use the Arize UI (Settings > API Keys).
 
 ```bash
-ax api-keys list                              # your own keys
-ax api-keys list --key-type service           # service keys only
-ax api-keys list --key-type user              # user keys only
-ax api-keys list --status active              # active only
-ax api-keys list --status deleted             # deleted/revoked keys
-ax api-keys list -l 50 -o json
-```
+ax api-keys list
+ax api-keys list --key-type service --status active -o json
 
-### Create
-
-Two key types:
-
-**User key** — authenticates as the creating user, inherits their full permissions. No space scope.
-
-```bash
+# User key — authenticates as creator, inherits their full permissions
 ax api-keys create --name "CI pipeline" --key-type user --expires-at "2027-01-01T00:00:00"
-```
 
-**Service key** — scoped to a specific space. Safe for automated pipelines and multi-tenant setups.
-
-```bash
-ax api-keys create \
-  --name "team-alpha-traces" \
-  --key-type service \
-  --space "team-alpha" \
-  --description "Trace writer for team-alpha CI/CD"
-
-# With expiration (recommended for rotation schedules)
+# Service key — scoped to a specific space (recommended for pipelines)
 ax api-keys create \
   --name "team-alpha-traces" \
   --key-type service \
   --space "team-alpha" \
   --expires-at "2027-01-01T00:00:00"
-```
 
-> **The raw key is displayed once.** Save it immediately in your secrets manager (e.g. GitHub Actions secret, Vault). It cannot be retrieved again.
-
-### Delete (revoke)
-
-```bash
 ax api-keys delete KEY_ID --force
-```
 
-### Refresh (zero-downtime rotation)
-
-Atomically revokes the old key and issues a new one with the same name, type, and scope.
-
-```bash
+# Zero-downtime rotation — revokes old key, issues new one with same scope
 ax api-keys refresh KEY_ID
-ax api-keys refresh KEY_ID --expires-at "2028-01-01T00:00:00"   # new expiration
+ax api-keys refresh KEY_ID --expires-at "2028-01-01T00:00:00"
 ```
 
-Get `KEY_ID` from `ax api-keys list -o json`.
+> **The raw key is displayed once.** Save it immediately in your secrets manager. It cannot be retrieved again.
 
 ---
 
-## Enterprise Workflows
+## Enterprise Workflows & Troubleshooting
 
-### Workflow 1: Onboard a New Team
-
-```bash
-# 1. Get the org ID
-ax organizations list -o json
-
-# 2. Create a space for the team
-ax spaces create --name "team-alpha" --organization-id ORG_ID
-
-# 3. Create or reuse a custom role
-ax roles create \
-  --name "Data Scientist" \
-  --permissions "PROJECT_READ,DATASET_CREATE,EXPERIMENT_CREATE" \
-  --description "Read traces, create datasets and run experiments"
-
-# 4. Get stable role IDs (for SAML mappings or role bindings)
-ax roles list --is-custom -o json
-
-# 5. Invite team members (or look up existing users)
-ax users create \
-  --full-name "Jane Doe" \
-  --email jane@example.com \
-  --role member \
-  --invite-mode email_link
-
-# 6. Get the user's global ID
-ax users list --email "jane@example.com" -o json
-
-# 7. Add the user to the org
-ax organizations add-user "Platform Team" --user-id USER_ID --role member
-
-# 8. Add the user to the space
-ax spaces add-user "team-alpha" --user-id USER_ID --role member
-
-# 9. Create a service key for the team's CI/CD pipeline
-ax api-keys create \
-  --name "team-alpha-service-key" \
-  --key-type service \
-  --space "team-alpha"
-```
-
-### Workflow 2: Configure SAML/SSO Role Mappings
-
-SAML group-to-role mappings require stable role IDs. Retrieve them:
-
-```bash
-# List all custom roles with their IDs
-ax roles list --is-custom -o json
-
-# Get a specific role's ID and permissions
-ax roles get "Data Scientist" -o json
-```
-
-Use the `id` field (base64 string like `Um9sZTo1...`) in your SAML `values.yaml` or IdP attribute mapping. These IDs are stable and do not change unless the role is deleted and recreated.
-
-### Workflow 3: Restrict a Project to Specific Users
-
-For fine-grained access where only certain users should see a project within a shared space:
-
-```bash
-# 1. Find the project ID
-ax projects list -l 100 -o json --space "team-alpha"
-
-# 2. Restrict the project (excludes space-level roles)
-ax resource-restrictions restrict --resource-id PROJECT_GLOBAL_ID
-
-# 3. Find the user's global ID
-ax users list --email "jane@example.com" -o json
-
-# 4. Find the role ID to assign
-ax roles list --is-custom -o json
-
-# 5. Explicitly grant access to allowed users on that project
-ax role-bindings create \
-  --user-id USER_GLOBAL_ID \
-  --role-id ROLE_GLOBAL_ID \
-  --resource-type PROJECT \
-  --resource-id PROJECT_GLOBAL_ID
-```
-
-### Workflow 4: Audit Access
-
-```bash
-# List all users and their status
-ax users list -l 100 -o json
-
-# List all custom roles with their permissions
-ax roles list --is-custom -o json
-
-# Inspect a specific role's permission set
-ax roles get "Data Scientist" -o json
-
-# List your own active API keys
-ax api-keys list --status active -o json
-```
-
-> **CLI audit limitations:** `ax` cannot enumerate role bindings (no `list` subcommand) or other users' API keys. For a full access audit — who has which role on which space/project, and all org-wide API keys — use the Arize UI (Settings > Users & Permissions and Settings > API Keys).
-
-### Workflow 5: Offboard a User
-
-`ax users delete` cascades to all org memberships, space memberships, API keys, and role bindings in one operation:
-
-```bash
-# 1. Find the user's global ID
-ax users list --email "jane@example.com" -o json
-
-# 2. Delete the user (cascades everything)
-ax users delete USER_ID --force
-```
-
-If you also need to deactivate the user in your IdP (to prevent SSO re-login), do that separately in Okta/Azure AD/etc. For real-time automated key invalidation on IdP deactivation, configure SCIM 2.0 provisioning.
-
-### Workflow 6: Multi-Tenant Service Key Management
-
-One service key per tenant space — scoped permissions, no org-admin required:
-
-```bash
-# Create a service key per tenant space
-ax api-keys create --name "tenant-acme-key" --key-type service --space "tenant-acme"
-ax api-keys create --name "tenant-beta-key" --key-type service --space "tenant-beta"
-
-# Rotate a key (zero-downtime, same scope)
-ax api-keys list --key-type service -o json   # find KEY_ID by name
-ax api-keys refresh KEY_ID
-```
-
-Service keys can only write traces to their scoped space — they cannot access other spaces or perform admin operations.
+Step-by-step workflows (onboard a team, SAML/SSO mappings, project restriction, offboarding, multi-tenant keys) and a troubleshooting table are in [references/REFERENCE.md](references/REFERENCE.md).
 
 ---
-
-## Troubleshooting
-
-| Error | Cause | Fix |
-|---|---|---|
-| `403 Forbidden` | Profile lacks admin privileges | Authenticate with an admin API key (`ax profiles update --api-key $ARIZE_API_KEY`) |
-| `401 Unauthorized` | Missing or invalid API key | See references/ax-profiles.md |
-| Role binding already exists | Idempotent — not an error | Safe to ignore; the existing binding is unchanged |
-| User not found in space add-user | User not yet an org member | Run `ax organizations add-user` first, then `ax spaces add-user` |
-| Role create fails with duplicate name | Name already in use | Use `ax roles list --is-custom` to find the existing role |
-| Service key create fails | `--space` missing or space doesn't exist | Verify with `ax spaces list`; `--space` is required for service keys |
-| Key value not saved | Raw key was not captured at creation | Refresh the key: `ax api-keys refresh KEY_ID` |
 
 ## Related Skills
 

--- a/skills/arize-admin/SKILL.md
+++ b/skills/arize-admin/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arize-admin
-description: Manages Arize users, organizations, spaces, roles, role bindings, resource restrictions, and API keys via the ax CLI. Use for enterprise admin workflows: inviting and offboarding users, onboarding new teams, creating custom roles for SAML/SSO mappings, assigning roles to users, restricting project-level access, and managing service keys for multi-tenant architectures. Covers ax users, ax organizations, ax spaces, ax roles, ax role-bindings, ax resource-restrictions, and ax api-keys.
+description: "Manages Arize users, organizations, spaces, roles, role bindings, resource restrictions, and API keys via the ax CLI. Use for enterprise admin workflows: inviting and offboarding users, onboarding new teams, creating custom roles for SAML/SSO mappings, assigning roles to users, restricting project-level access, and managing service keys for multi-tenant architectures. Covers ax users, ax organizations, ax spaces, ax roles, ax role-bindings, ax resource-restrictions, and ax api-keys."
 metadata:
   author: arize
   version: "1.0"

--- a/skills/arize-admin/SKILL.md
+++ b/skills/arize-admin/SKILL.md
@@ -4,7 +4,7 @@ description: Manages Arize users, organizations, spaces, roles, role bindings, r
 metadata:
   author: arize
   version: "1.0"
-compatibility: Requires the ax CLI (≥ 0.14.0) and a configured Arize profile with org-admin privileges.
+compatibility: Requires the ax CLI (≥ 0.19.0) and a configured Arize profile with org-admin privileges.
 ---
 
 # Arize Admin Skill
@@ -150,8 +150,6 @@ ax roles delete "Data Scientist" --force   # predefined roles cannot be deleted
 ## Role Bindings
 
 Fine-grained assignment of a custom role to a user on a specific resource (space or project).
-
-> **No list command.** To enumerate all bindings on a resource, use the Arize UI (Settings > Users & Permissions).
 
 ```bash
 # Assign at space level

--- a/skills/arize-admin/SKILL.md
+++ b/skills/arize-admin/SKILL.md
@@ -13,6 +13,13 @@ Programmatic management of Arize users, organizations, spaces, roles, permission
 
 > **Privilege requirement:** Most operations require **org-admin** or **account-admin** privileges. If commands return `403 Forbidden`, the authenticated profile lacks sufficient permissions.
 
+> **Destructive-action rule:** Commands that delete, remove, or irreversibly modify resources (`delete`, `remove-user`, `unrestrict`) require **explicit user confirmation before execution**. When a user asks you to perform one of these operations:
+> 1. Summarize exactly what will happen (e.g., "This will delete user jane@example.com and cascade-remove all their org/space memberships, API keys, and role bindings.")
+> 2. Ask the user to confirm (use `AskUserQuestion`).
+> 3. Only after the user confirms, run the command with `--force` to skip the CLI's interactive prompt.
+>
+> Never run a `--force` deletion without confirming with the user first.
+
 ## When to Use
 
 - Invite users to the account, assign them to orgs and spaces
@@ -65,7 +72,7 @@ ax users create \
 ax users update USER_ID --full-name "Jane Smith"
 ax users update USER_ID --is-developer          # grant developer flag
 
-ax users delete USER_ID --force   # cascades: org/space memberships, API keys, role bindings
+ax users delete USER_ID --force   # ⚠ confirm first — cascades: org/space memberships, API keys, role bindings
 
 ax users resend-invitation USER_ID
 ax users reset-password USER_ID
@@ -91,7 +98,7 @@ ax organizations update "Platform Team" --name "ML Platform" --description "Upda
 # Add user (must exist in account first)
 ax organizations add-user "Platform Team" --user-id USER_ID --role member
 
-# Remove user (also removes from all child spaces)
+# Remove user (also removes from all child spaces) — ⚠ confirm first
 ax organizations remove-user "Platform Team" --user-id USER_ID --force
 ```
 
@@ -112,11 +119,11 @@ ax spaces create --name "team-alpha" --organization-id ORG_ID
 
 ax spaces update "team-alpha" --name "team-alpha-v2"
 
-ax spaces delete "team-alpha" --force   # irreversible; deletes all resources
+ax spaces delete "team-alpha" --force   # ⚠ confirm first — irreversible; deletes all resources
 
 # User must be an org member before being added to a space
 ax spaces add-user "team-alpha" --user-id USER_ID --role member
-ax spaces remove-user "team-alpha" --user-id USER_ID --force
+ax spaces remove-user "team-alpha" --user-id USER_ID --force   # ⚠ confirm first
 ```
 
 ---
@@ -140,7 +147,7 @@ ax roles create \
 
 ax roles update "Data Scientist" --permissions "PROJECT_READ,DATASET_CREATE,EXPERIMENT_CREATE,EVALUATOR_CREATE"
 
-ax roles delete "Data Scientist" --force   # predefined roles cannot be deleted
+ax roles delete "Data Scientist" --force   # ⚠ confirm first — predefined roles cannot be deleted
 ```
 
 **Finding available permissions:** Run `ax roles get <predefined-role> -o json` on a system role (e.g. `Member`, `Admin`) to see valid permission names.
@@ -168,7 +175,7 @@ ax role-bindings create \
 
 ax role-bindings get BINDING_ID
 ax role-bindings update BINDING_ID --role-id NEW_ROLE_ID
-ax role-bindings delete BINDING_ID --force
+ax role-bindings delete BINDING_ID --force   # ⚠ confirm first
 ```
 
 Idempotent — if a binding already exists for the user on that resource, exits without error.
@@ -181,7 +188,7 @@ Restricts a **project** so only users with an explicit role binding on that proj
 
 ```bash
 ax resource-restrictions restrict --resource-id PROJECT_GLOBAL_ID     # idempotent
-ax resource-restrictions unrestrict --resource-id PROJECT_GLOBAL_ID --force
+ax resource-restrictions unrestrict --resource-id PROJECT_GLOBAL_ID --force   # ⚠ confirm first
 
 # Finding project IDs
 ax projects list -l 100 -o json --space "my-workspace"
@@ -207,7 +214,7 @@ ax api-keys create \
   --space "team-alpha" \
   --expires-at "2027-01-01T00:00:00"
 
-ax api-keys delete KEY_ID --force
+ax api-keys delete KEY_ID --force   # ⚠ confirm first
 
 # Zero-downtime rotation — revokes old key, issues new one with same scope
 ax api-keys refresh KEY_ID

--- a/skills/arize-admin/SKILL.md
+++ b/skills/arize-admin/SKILL.md
@@ -1,0 +1,600 @@
+---
+name: arize-admin
+description: Manages Arize users, organizations, spaces, roles, role bindings, resource restrictions, and API keys via the ax CLI. Use for enterprise admin workflows: inviting and offboarding users, onboarding new teams, creating custom roles for SAML/SSO mappings, assigning roles to users, restricting project-level access, and managing service keys for multi-tenant architectures. Covers ax users, ax organizations, ax spaces, ax roles, ax role-bindings, ax resource-restrictions, and ax api-keys.
+metadata:
+  author: arize
+  version: "1.0"
+compatibility: Requires the ax CLI (≥ 0.14.0) and a configured Arize profile with org-admin privileges.
+---
+
+# Arize Admin Skill
+
+Programmatic management of Arize users, organizations, spaces, roles, permissions, and API keys — the building blocks for enterprise access control.
+
+> **Privilege requirement:** Most operations in this skill require **org-admin** or **account-admin** privileges. If commands return `403 Forbidden`, the authenticated profile does not have sufficient permissions.
+
+## When to Use
+
+- Invite users to the account, assign them to orgs and spaces
+- Offboard a user and revoke all their access in one command
+- Onboard a new team: create a space, create a custom role, assign users, generate a service key
+- Create custom roles for SAML/SSO attribute mappings (need stable role IDs)
+- List roles and their IDs to configure an IdP
+- Assign or change a user's role in a space or on a project
+- Restrict a project so only explicitly bound users can access it
+- Create scoped service keys for CI/CD pipelines or multi-tenant architectures
+- Rotate or revoke API keys
+
+## Concepts
+
+- **Organization** — a named grouping within an account (e.g. one per business unit). Spaces live inside organizations. Users are added to the account first, then to orgs, then to spaces.
+- **Space** — a workspace that isolates traces, datasets, and projects. A user must be an org member before they can be added to a space within that org.
+- **Role** — a named set of permissions. Predefined roles are system-managed. Custom roles are created by admins. The roles for org/space membership (`admin`, `member`, `read-only`, `annotator`) are separate from custom RBAC roles used with `ax role-bindings`.
+- **Role binding** — fine-grained assignment of a custom role to a user on a specific resource (a space or a project).
+- **Resource restriction** — marks a project so that only users with an explicit role binding on that project can access it. Space-level roles are excluded.
+- **API key** — either a *user* key (authenticates as the creator, full user permissions) or a *service* key (scoped to a specific space, for automated pipelines).
+
+## Prerequisites
+
+Proceed directly — run the `ax` command you need. Do NOT check versions or profiles upfront.
+
+If an `ax` command fails:
+- `command not found` or version error → see [references/ax-setup.md](references/ax-setup.md)
+- `401 Unauthorized` / missing API key → run `ax profiles show`; follow [references/ax-profiles.md](references/ax-profiles.md)
+- `403 Forbidden` → the active profile lacks admin privileges; ask the user to authenticate with an admin key
+- **Security:** Never read `.env` files or search the filesystem for credentials. Use `ax profiles` for Arize credentials. Never echo, log, or display raw API key values.
+
+---
+
+## Users
+
+Manage account-level users. A user must exist in the account before they can be added to an org or space.
+
+**Account-level roles:** `admin`, `member`, `annotator`
+
+### List
+
+```bash
+ax users list                                  # all users
+ax users list --email "jane"                   # substring filter on email
+ax users list --status active                  # active users only
+ax users list --status invited                 # pending invitations
+ax users list -l 100 -o json                   # paginate, get global IDs
+```
+
+Use `ax users list -o json` to look up a user's global ID (base64) for use with `ax role-bindings`, `ax organizations add-user`, and `ax spaces add-user`.
+
+### Get
+
+```bash
+ax users get USER_ID                           # by global base64 ID
+```
+
+### Create (invite)
+
+Creates the user account and optionally sends an invitation.
+
+```bash
+# Send an email invitation
+ax users create \
+  --full-name "Jane Doe" \
+  --email jane@example.com \
+  --role member \
+  --invite-mode email_link
+
+# Create without sending an invite (e.g. for SSO/JIT provisioning)
+ax users create \
+  --full-name "Jane Doe" \
+  --email jane@example.com \
+  --role member \
+  --invite-mode none
+
+# Send a temporary password instead of a link
+ax users create \
+  --full-name "Jane Doe" \
+  --email jane@example.com \
+  --role admin \
+  --invite-mode temporary_password
+```
+
+**Invite modes:**
+
+| Mode                 | Description                                      |
+|----------------------|--------------------------------------------------|
+| `none`               | Create the user without sending any invitation   |
+| `email_link`         | Send an invitation email with a sign-in link     |
+| `temporary_password` | Send an email with a one-time temporary password |
+
+### Update
+
+```bash
+ax users update USER_ID --full-name "Jane Smith"
+ax users update USER_ID --is-developer          # grant developer flag
+ax users update USER_ID --no-is-developer       # revoke developer flag
+```
+
+### Delete
+
+Deletes the user and **cascades to all organization memberships, space memberships, API keys, and role bindings**. This is the primary offboarding command.
+
+```bash
+ax users delete USER_ID --force
+```
+
+Get `USER_ID` from `ax users list -o json`.
+
+### Re-invite / Reset password
+
+```bash
+ax users resend-invitation USER_ID    # resend invite to a pending user
+ax users reset-password USER_ID       # send a password-reset email
+```
+
+---
+
+## Organizations
+
+**Organization roles:** `admin`, `member`, `read-only`, `annotator`
+
+### List
+
+```bash
+ax organizations list
+ax organizations list --name "platform"        # substring filter
+ax organizations list -l 100 -o json
+```
+
+### Get
+
+```bash
+ax organizations get "Platform Team"           # by name
+ax organizations get ORG_ID                    # by base64 ID
+```
+
+### Create
+
+```bash
+ax organizations create --name "Platform Team" --description "Core ML platform"
+```
+
+Names must be unique within the account.
+
+### Update
+
+```bash
+ax organizations update "Platform Team" --name "ML Platform" --description "Updated desc"
+ax organizations update ORG_ID --description ""   # clear description
+```
+
+### Add / remove users
+
+Add a user to an org (or update their role if already a member). The user must exist in the account — create them first with `ax users create` if needed.
+
+```bash
+ax organizations add-user "Platform Team" --user-id USER_ID --role member
+ax organizations add-user "Platform Team" --user-id USER_ID --role admin
+```
+
+Remove a user from an org. **Also removes them from all child spaces within that org.**
+
+```bash
+ax organizations remove-user "Platform Team" --user-id USER_ID --force
+```
+
+---
+
+## Spaces
+
+**Space roles:** `admin`, `member`, `read-only`, `annotator`
+
+### List
+
+```bash
+ax spaces list
+ax spaces list --organization-id ORG_ID        # filter to one org
+ax spaces list -l 100 -o json
+```
+
+### Get
+
+```bash
+ax spaces get "my-workspace"
+ax spaces get U3BhY2U6...                       # base64 ID
+```
+
+### Create
+
+`--organization-id` is required. Get the org ID from `ax organizations list -o json`.
+
+```bash
+ax spaces create --name "team-alpha" --organization-id ORG_ID
+ax spaces create --name "team-alpha" --organization-id ORG_ID --description "Alpha team workspace"
+```
+
+### Update
+
+```bash
+ax spaces update "team-alpha" --name "team-alpha-v2"
+ax spaces update SPACE_ID --description "Updated description"
+```
+
+### Delete
+
+Deletes the space **and all resources within it** (traces, datasets, projects, etc.). Irreversible.
+
+```bash
+ax spaces delete "team-alpha" --force       # --force skips confirmation
+```
+
+### Add / remove users
+
+The user must already be a member of the space's **parent organization** before they can be added to a space.
+
+```bash
+ax spaces add-user "team-alpha" --user-id USER_ID --role member
+ax spaces add-user "team-alpha" --user-id USER_ID --role admin
+```
+
+Remove a user from a space (does not remove them from the parent org).
+
+```bash
+ax spaces remove-user "team-alpha" --user-id USER_ID --force
+```
+
+---
+
+## Roles
+
+Custom RBAC roles used with `ax role-bindings` for fine-grained project/space access control. Separate from the simpler `admin`/`member`/`read-only`/`annotator` roles used in org and space membership.
+
+### List
+
+```bash
+ax roles list                          # all roles (predefined + custom)
+ax roles list --is-predefined          # system roles only
+ax roles list --is-custom              # custom roles only
+ax roles list -l 100 -o json           # paginate — get IDs for SAML mappings
+```
+
+Use `--is-custom -o json` to retrieve stable role IDs for SAML attribute mapping in your IdP config.
+
+### Get
+
+```bash
+ax roles get "Data Scientist"
+ax roles get ROLE_ID                   # by base64 ID
+```
+
+Returns the role's permissions list — inspect a predefined role to discover available permission names.
+
+### Create
+
+`--permissions` is comma-separated. At least one permission is required. Names must be unique within the account.
+
+```bash
+ax roles create \
+  --name "Data Scientist" \
+  --permissions "PROJECT_READ,DATASET_CREATE,EXPERIMENT_CREATE" \
+  --description "Read traces, create datasets and experiments — no admin"
+
+ax roles create \
+  --name "Trace Writer" \
+  --permissions "PROJECT_READ,TRACE_CREATE" \
+  --description "Service accounts that send traces only"
+```
+
+**Finding available permissions:** Run `ax roles get <predefined-role> -o json` on a system role (e.g. `Member`, `Admin`) to see its full permission set — those names are valid for custom roles.
+
+### Update
+
+When `--permissions` is provided, it **fully replaces** the existing permission set (not additive).
+
+```bash
+ax roles update "Data Scientist" --permissions "PROJECT_READ,DATASET_CREATE,EXPERIMENT_CREATE,EVALUATOR_CREATE"
+ax roles update "Data Scientist" --name "ML Engineer" --description "Updated scope"
+```
+
+Predefined (system) roles cannot be updated.
+
+### Delete
+
+```bash
+ax roles delete "Data Scientist" --force
+```
+
+Predefined roles cannot be deleted.
+
+---
+
+## Role Bindings
+
+Fine-grained assignment of a custom role to a user on a specific resource (space or project). Use this when the simpler org/space membership roles (`admin`, `member`, etc.) aren't granular enough.
+
+> **No list command:** `ax role-bindings` does not have a `list` subcommand. To enumerate all bindings on a resource, use the Arize UI (Settings > Users & Permissions). You can only `get` a binding if you already know its ID.
+
+> **Getting user IDs:** Run `ax users list -o json` to get a user's global base64 ID for use with `--user-id`.
+
+### Create
+
+```bash
+# Assign a role at the space level
+ax role-bindings create \
+  --user-id USER_GLOBAL_ID \
+  --role-id ROLE_GLOBAL_ID \
+  --resource-type SPACE \
+  --resource-id SPACE_GLOBAL_ID
+
+# Assign a role at the project level (for fine-grained access)
+ax role-bindings create \
+  --user-id USER_GLOBAL_ID \
+  --role-id ROLE_GLOBAL_ID \
+  --resource-type PROJECT \
+  --resource-id PROJECT_GLOBAL_ID
+```
+
+Idempotent — if a binding already exists for the user on that resource, the command exits without error.
+
+### Get
+
+```bash
+ax role-bindings get BINDING_ID
+```
+
+### Update (change the assigned role)
+
+```bash
+ax role-bindings update BINDING_ID --role-id NEW_ROLE_ID
+```
+
+### Delete (revoke access)
+
+```bash
+ax role-bindings delete BINDING_ID --force
+```
+
+---
+
+## Resource Restrictions
+
+Restricts a **project** so that only users with an explicit role binding on that project can access it. Roles bound at the space, org, or account level are excluded from that project.
+
+Currently only `PROJECT` resources are supported.
+
+### Restrict a project
+
+```bash
+ax resource-restrictions restrict --resource-id PROJECT_GLOBAL_ID
+```
+
+Idempotent — safe to run even if already restricted.
+
+### Unrestrict a project
+
+Removes the restriction so space-level roles apply again.
+
+```bash
+ax resource-restrictions unrestrict --resource-id PROJECT_GLOBAL_ID --force
+```
+
+### Finding project IDs
+
+```bash
+ax projects list -l 100 -o json --space "my-workspace"
+```
+
+Use the `id` field (base64) as `--resource-id`.
+
+---
+
+## API Keys
+
+> **Scope:** `ax api-keys list` returns only keys owned by the **authenticated user**. There is no CLI command to list or revoke another user's keys. For org-wide key auditing, use the Arize UI (Settings > API Keys).
+
+### List
+
+```bash
+ax api-keys list                              # your own keys
+ax api-keys list --key-type service           # service keys only
+ax api-keys list --key-type user              # user keys only
+ax api-keys list --status active              # active only
+ax api-keys list --status deleted             # deleted/revoked keys
+ax api-keys list -l 50 -o json
+```
+
+### Create
+
+Two key types:
+
+**User key** — authenticates as the creating user, inherits their full permissions. No space scope.
+
+```bash
+ax api-keys create --name "CI pipeline" --key-type user --expires-at "2027-01-01T00:00:00"
+```
+
+**Service key** — scoped to a specific space. Safe for automated pipelines and multi-tenant setups.
+
+```bash
+ax api-keys create \
+  --name "team-alpha-traces" \
+  --key-type service \
+  --space "team-alpha" \
+  --description "Trace writer for team-alpha CI/CD"
+
+# With expiration (recommended for rotation schedules)
+ax api-keys create \
+  --name "team-alpha-traces" \
+  --key-type service \
+  --space "team-alpha" \
+  --expires-at "2027-01-01T00:00:00"
+```
+
+> **The raw key is displayed once.** Save it immediately in your secrets manager (e.g. GitHub Actions secret, Vault). It cannot be retrieved again.
+
+### Delete (revoke)
+
+```bash
+ax api-keys delete KEY_ID --force
+```
+
+### Refresh (zero-downtime rotation)
+
+Atomically revokes the old key and issues a new one with the same name, type, and scope.
+
+```bash
+ax api-keys refresh KEY_ID
+ax api-keys refresh KEY_ID --expires-at "2028-01-01T00:00:00"   # new expiration
+```
+
+Get `KEY_ID` from `ax api-keys list -o json`.
+
+---
+
+## Enterprise Workflows
+
+### Workflow 1: Onboard a New Team
+
+```bash
+# 1. Get the org ID
+ax organizations list -o json
+
+# 2. Create a space for the team
+ax spaces create --name "team-alpha" --organization-id ORG_ID
+
+# 3. Create or reuse a custom role
+ax roles create \
+  --name "Data Scientist" \
+  --permissions "PROJECT_READ,DATASET_CREATE,EXPERIMENT_CREATE" \
+  --description "Read traces, create datasets and run experiments"
+
+# 4. Get stable role IDs (for SAML mappings or role bindings)
+ax roles list --is-custom -o json
+
+# 5. Invite team members (or look up existing users)
+ax users create \
+  --full-name "Jane Doe" \
+  --email jane@example.com \
+  --role member \
+  --invite-mode email_link
+
+# 6. Get the user's global ID
+ax users list --email "jane@example.com" -o json
+
+# 7. Add the user to the org
+ax organizations add-user "Platform Team" --user-id USER_ID --role member
+
+# 8. Add the user to the space
+ax spaces add-user "team-alpha" --user-id USER_ID --role member
+
+# 9. Create a service key for the team's CI/CD pipeline
+ax api-keys create \
+  --name "team-alpha-service-key" \
+  --key-type service \
+  --space "team-alpha"
+```
+
+### Workflow 2: Configure SAML/SSO Role Mappings
+
+SAML group-to-role mappings require stable role IDs. Retrieve them:
+
+```bash
+# List all custom roles with their IDs
+ax roles list --is-custom -o json
+
+# Get a specific role's ID and permissions
+ax roles get "Data Scientist" -o json
+```
+
+Use the `id` field (base64 string like `Um9sZTo1...`) in your SAML `values.yaml` or IdP attribute mapping. These IDs are stable and do not change unless the role is deleted and recreated.
+
+### Workflow 3: Restrict a Project to Specific Users
+
+For fine-grained access where only certain users should see a project within a shared space:
+
+```bash
+# 1. Find the project ID
+ax projects list -l 100 -o json --space "team-alpha"
+
+# 2. Restrict the project (excludes space-level roles)
+ax resource-restrictions restrict --resource-id PROJECT_GLOBAL_ID
+
+# 3. Find the user's global ID
+ax users list --email "jane@example.com" -o json
+
+# 4. Find the role ID to assign
+ax roles list --is-custom -o json
+
+# 5. Explicitly grant access to allowed users on that project
+ax role-bindings create \
+  --user-id USER_GLOBAL_ID \
+  --role-id ROLE_GLOBAL_ID \
+  --resource-type PROJECT \
+  --resource-id PROJECT_GLOBAL_ID
+```
+
+### Workflow 4: Audit Access
+
+```bash
+# List all users and their status
+ax users list -l 100 -o json
+
+# List all custom roles with their permissions
+ax roles list --is-custom -o json
+
+# Inspect a specific role's permission set
+ax roles get "Data Scientist" -o json
+
+# List your own active API keys
+ax api-keys list --status active -o json
+```
+
+> **CLI audit limitations:** `ax` cannot enumerate role bindings (no `list` subcommand) or other users' API keys. For a full access audit — who has which role on which space/project, and all org-wide API keys — use the Arize UI (Settings > Users & Permissions and Settings > API Keys).
+
+### Workflow 5: Offboard a User
+
+`ax users delete` cascades to all org memberships, space memberships, API keys, and role bindings in one operation:
+
+```bash
+# 1. Find the user's global ID
+ax users list --email "jane@example.com" -o json
+
+# 2. Delete the user (cascades everything)
+ax users delete USER_ID --force
+```
+
+If you also need to deactivate the user in your IdP (to prevent SSO re-login), do that separately in Okta/Azure AD/etc. For real-time automated key invalidation on IdP deactivation, configure SCIM 2.0 provisioning.
+
+### Workflow 6: Multi-Tenant Service Key Management
+
+One service key per tenant space — scoped permissions, no org-admin required:
+
+```bash
+# Create a service key per tenant space
+ax api-keys create --name "tenant-acme-key" --key-type service --space "tenant-acme"
+ax api-keys create --name "tenant-beta-key" --key-type service --space "tenant-beta"
+
+# Rotate a key (zero-downtime, same scope)
+ax api-keys list --key-type service -o json   # find KEY_ID by name
+ax api-keys refresh KEY_ID
+```
+
+Service keys can only write traces to their scoped space — they cannot access other spaces or perform admin operations.
+
+---
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|---|---|---|
+| `403 Forbidden` | Profile lacks admin privileges | Authenticate with an admin API key (`ax profiles update --api-key $ARIZE_API_KEY`) |
+| `401 Unauthorized` | Missing or invalid API key | See references/ax-profiles.md |
+| Role binding already exists | Idempotent — not an error | Safe to ignore; the existing binding is unchanged |
+| User not found in space add-user | User not yet an org member | Run `ax organizations add-user` first, then `ax spaces add-user` |
+| Role create fails with duplicate name | Name already in use | Use `ax roles list --is-custom` to find the existing role |
+| Service key create fails | `--space` missing or space doesn't exist | Verify with `ax spaces list`; `--space` is required for service keys |
+| Key value not saved | Raw key was not captured at creation | Refresh the key: `ax api-keys refresh KEY_ID` |
+
+## Related Skills
+
+- **arize-instrumentation**: Set up tracing in an LLM app once a space is ready.
+- **arize-trace**: Export and inspect traces within a managed space.
+- **arize-dataset**: Create and manage datasets within a space.

--- a/skills/arize-admin/references/REFERENCE.md
+++ b/skills/arize-admin/references/REFERENCE.md
@@ -1,0 +1,141 @@
+# Arize Admin — Enterprise Workflows & Troubleshooting
+
+## Workflow 1: Onboard a New Team
+
+```bash
+# 1. Get the org ID
+ax organizations list -o json
+
+# 2. Create a space for the team
+ax spaces create --name "team-alpha" --organization-id ORG_ID
+
+# 3. Create or reuse a custom role
+ax roles create \
+  --name "Data Scientist" \
+  --permissions "PROJECT_READ,DATASET_CREATE,EXPERIMENT_CREATE" \
+  --description "Read traces, create datasets and run experiments"
+
+# 4. Get stable role IDs (for SAML mappings or role bindings)
+ax roles list --is-custom -o json
+
+# 5. Invite team members (or look up existing users)
+ax users create \
+  --full-name "Jane Doe" \
+  --email jane@example.com \
+  --role member \
+  --invite-mode email_link
+
+# 6. Get the user's global ID
+ax users list --email "jane@example.com" -o json
+
+# 7. Add the user to the org
+ax organizations add-user "Platform Team" --user-id USER_ID --role member
+
+# 8. Add the user to the space
+ax spaces add-user "team-alpha" --user-id USER_ID --role member
+
+# 9. Create a service key for the team's CI/CD pipeline
+ax api-keys create \
+  --name "team-alpha-service-key" \
+  --key-type service \
+  --space "team-alpha"
+```
+
+## Workflow 2: Configure SAML/SSO Role Mappings
+
+SAML group-to-role mappings require stable role IDs. Retrieve them:
+
+```bash
+# List all custom roles with their IDs
+ax roles list --is-custom -o json
+
+# Get a specific role's ID and permissions
+ax roles get "Data Scientist" -o json
+```
+
+Use the `id` field (base64 string like `Um9sZTo1...`) in your SAML `values.yaml` or IdP attribute mapping. These IDs are stable and do not change unless the role is deleted and recreated.
+
+## Workflow 3: Restrict a Project to Specific Users
+
+```bash
+# 1. Find the project ID
+ax projects list -l 100 -o json --space "team-alpha"
+
+# 2. Restrict the project (excludes space-level roles)
+ax resource-restrictions restrict --resource-id PROJECT_GLOBAL_ID
+
+# 3. Find the user's global ID
+ax users list --email "jane@example.com" -o json
+
+# 4. Find the role ID to assign
+ax roles list --is-custom -o json
+
+# 5. Explicitly grant access to allowed users on that project
+ax role-bindings create \
+  --user-id USER_GLOBAL_ID \
+  --role-id ROLE_GLOBAL_ID \
+  --resource-type PROJECT \
+  --resource-id PROJECT_GLOBAL_ID
+```
+
+## Workflow 4: Audit Access
+
+```bash
+# List all users and their status
+ax users list -l 100 -o json
+
+# List all custom roles with their permissions
+ax roles list --is-custom -o json
+
+# Inspect a specific role's permission set
+ax roles get "Data Scientist" -o json
+
+# List your own active API keys
+ax api-keys list --status active -o json
+```
+
+> **CLI audit limitations:** `ax` cannot enumerate role bindings (no `list` subcommand) or other users' API keys. For a full access audit, use the Arize UI (Settings > Users & Permissions and Settings > API Keys).
+
+## Workflow 5: Offboard a User
+
+`ax users delete` cascades to all org memberships, space memberships, API keys, and role bindings in one operation:
+
+```bash
+# 1. Find the user's global ID
+ax users list --email "jane@example.com" -o json
+
+# 2. Delete the user (cascades everything)
+ax users delete USER_ID --force
+```
+
+If you also need to deactivate the user in your IdP (to prevent SSO re-login), do that separately in Okta/Azure AD/etc. For real-time automated key invalidation on IdP deactivation, configure SCIM 2.0 provisioning.
+
+## Workflow 6: Multi-Tenant Service Key Management
+
+One service key per tenant space — scoped permissions, no org-admin required:
+
+```bash
+# Create a service key per tenant space
+ax api-keys create --name "tenant-acme-key" --key-type service --space "tenant-acme"
+ax api-keys create --name "tenant-beta-key" --key-type service --space "tenant-beta"
+
+# Rotate a key (zero-downtime, same scope)
+ax api-keys list --key-type service -o json   # find KEY_ID by name
+ax api-keys refresh KEY_ID
+```
+
+Service keys can only write traces to their scoped space — they cannot access other spaces or perform admin operations.
+
+---
+
+## Troubleshooting
+
+| Error | Cause | Fix |
+|---|---|---|
+| `403 Forbidden` | Profile lacks admin privileges | Authenticate with an admin API key (`ax profiles update --api-key $ARIZE_API_KEY`) |
+| `401 Unauthorized` | Missing or invalid API key | See [ax-profiles.md](ax-profiles.md) |
+| Role binding already exists | Idempotent — not an error | Safe to ignore; the existing binding is unchanged |
+| User not found in space add-user | User not yet an org member | Run `ax organizations add-user` first, then `ax spaces add-user` |
+| Role create fails with duplicate name | Name already in use | Use `ax roles list --is-custom` to find the existing role |
+| Service key create fails | `--space` missing or space doesn't exist | Verify with `ax spaces list`; `--space` is required for service keys |
+| Key value not saved | Raw key was not captured at creation | Refresh the key: `ax api-keys refresh KEY_ID` |

--- a/skills/arize-admin/references/REFERENCE.md
+++ b/skills/arize-admin/references/REFERENCE.md
@@ -98,13 +98,18 @@ ax api-keys list --status active -o json
 
 ## Workflow 5: Offboard a User
 
-`ax users delete` cascades to all org memberships, space memberships, API keys, and role bindings in one operation:
+`ax users delete` cascades to all org memberships, space memberships, API keys, and role bindings in one operation.
+
+**Always confirm with the user before running the delete.** Summarize the cascade impact, then ask for explicit confirmation.
 
 ```bash
 # 1. Find the user's global ID
 ax users list --email "jane@example.com" -o json
 
-# 2. Delete the user (cascades everything)
+# 2. Confirm with the user: "Delete jane@example.com? This will cascade-remove
+#    all org/space memberships, API keys, and role bindings."
+
+# 3. After user confirms, delete
 ax users delete USER_ID --force
 ```
 

--- a/skills/arize-admin/references/ax-profiles.md
+++ b/skills/arize-admin/references/ax-profiles.md
@@ -1,0 +1,115 @@
+# ax Profile Setup
+
+Consult this when authentication fails (401, missing profile, missing API key). Do NOT run these checks proactively.
+
+Use this when there is no profile, or a profile has incorrect settings (wrong API key, wrong region, etc.).
+
+## 1. Inspect the current state
+
+```bash
+ax profiles show
+```
+
+Look at the output to understand what's configured:
+- `API Key: (not set)` or missing → key needs to be created/updated
+- No profile output or "No profiles found" → no profile exists yet
+- Connected but getting `401 Unauthorized` → key is wrong or expired
+- Connected but wrong endpoint/region → region needs to be updated
+
+## 2. Fix a misconfigured profile
+
+If a profile exists but one or more settings are wrong, patch only what's broken.
+
+**Never pass a raw API key value as a flag.** Always reference it via the `ARIZE_API_KEY` environment variable. If the variable is not already set in the shell, instruct the user to set it first, then run the command:
+
+```bash
+# If ARIZE_API_KEY is already exported in the shell:
+ax profiles update --api-key $ARIZE_API_KEY
+
+# Fix the region (no secret involved — safe to run directly)
+ax profiles update --region us-east-1b
+
+# Fix both at once
+ax profiles update --api-key $ARIZE_API_KEY --region us-east-1b
+```
+
+`update` only changes the fields you specify — all other settings are preserved. If no profile name is given, the active profile is updated.
+
+## 3. Create a new profile
+
+If no profile exists, or if the existing profile needs to point to a completely different setup (different org, different region):
+
+**Always reference the key via `$ARIZE_API_KEY`, never inline a raw value.**
+
+```bash
+# Requires ARIZE_API_KEY to be exported in the shell first
+ax profiles create --api-key $ARIZE_API_KEY
+
+# Create with a region
+ax profiles create --api-key $ARIZE_API_KEY --region us-east-1b
+
+# Create a named profile
+ax profiles create work --api-key $ARIZE_API_KEY --region us-east-1b
+```
+
+To use a named profile with any `ax` command, add `-p NAME`:
+```bash
+ax spans export PROJECT -p work
+```
+
+## 4. Getting the API key
+
+**Never ask the user to paste their API key into the chat. Never log, echo, or display an API key value.**
+
+If `ARIZE_API_KEY` is not already set, instruct the user to export it in their shell:
+
+```bash
+export ARIZE_API_KEY="..."   # user pastes their key here in their own terminal
+```
+
+They can find their key at https://app.arize.com/admin > API Keys. Recommend they create a **scoped service key** (not a personal user key) — service keys are not tied to an individual account and are safer for programmatic use. Keys are space-scoped — make sure they copy the key for the correct space.
+
+Once the user confirms the variable is set, proceed with `ax profiles create --api-key $ARIZE_API_KEY` or `ax profiles update --api-key $ARIZE_API_KEY` as described above.
+
+## 5. Verify
+
+After any create or update:
+
+```bash
+ax profiles show
+```
+
+Confirm the API key and region are correct, then retry the original command.
+
+## Space
+
+There is no profile flag for space. Save it as an environment variable — accepts a space **name** (e.g., `my-workspace`) or a base64 space **ID** (e.g., `U3BhY2U6...`). Find yours with `ax spaces list -o json`.
+
+**macOS/Linux** — add to `~/.zshrc` or `~/.bashrc`:
+```bash
+export ARIZE_SPACE="my-workspace"    # name or base64 ID
+```
+Then `source ~/.zshrc` (or restart terminal).
+
+**Windows (PowerShell):**
+```powershell
+[System.Environment]::SetEnvironmentVariable('ARIZE_SPACE', 'my-workspace', 'User')
+```
+Restart terminal for it to take effect.
+
+## Save Credentials for Future Use
+
+At the **end of the session**, if the user manually provided any credentials during this conversation **and** those values were NOT already loaded from a saved profile or environment variable, offer to save them.
+
+**Skip this entirely if:**
+- The API key was already loaded from an existing profile or `ARIZE_API_KEY` env var
+- The space was already set via `ARIZE_SPACE` env var
+- The user only used base64 project IDs (no space was needed)
+
+**How to offer:** Use **AskQuestion**: *"Would you like to save your Arize credentials so you don't have to enter them next time?"* with options `"Yes, save them"` / `"No thanks"`.
+
+**If the user says yes:**
+
+1. **API key** — Run `ax profiles show` to check the current state. Then run `ax profiles create --api-key $ARIZE_API_KEY` or `ax profiles update --api-key $ARIZE_API_KEY` (the key must already be exported as an env var — never pass a raw key value).
+
+2. **Space** — See the Space section above to persist it as an environment variable.

--- a/skills/arize-admin/references/ax-setup.md
+++ b/skills/arize-admin/references/ax-setup.md
@@ -1,0 +1,38 @@
+# ax CLI — Troubleshooting
+
+Consult this only when an `ax` command fails. Do NOT run these checks proactively.
+
+## Check version first
+
+If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.14.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
+
+## `ax: command not found`
+
+**macOS/Linux:**
+1. Check common locations: `~/.local/bin/ax`, `~/Library/Python/*/bin/ax`
+2. Install: `uv tool install arize-ax-cli` (preferred), `pipx install arize-ax-cli`, or `pip install arize-ax-cli`
+3. Add to PATH if needed: `export PATH="$HOME/.local/bin:$PATH"`
+
+**Windows (PowerShell):**
+1. Check: `Get-Command ax` or `where.exe ax`
+2. Common locations: `%APPDATA%\Python\Scripts\ax.exe`, `%LOCALAPPDATA%\Programs\Python\Python*\Scripts\ax.exe`
+3. Install: `pip install arize-ax-cli`
+4. Add to PATH: `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
+
+## Version too old (below 0.14.0)
+
+Upgrade: `uv tool install --force --reinstall arize-ax-cli`, `pipx upgrade arize-ax-cli`, or `pip install --upgrade arize-ax-cli`
+
+## SSL/certificate error
+
+- macOS: `export SSL_CERT_FILE=/etc/ssl/cert.pem`
+- Linux: `export SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt`
+- Fallback: `export SSL_CERT_FILE=$(python -c "import certifi; print(certifi.where())")`
+
+## Subcommand not recognized
+
+Upgrade ax (see above) or use the closest available alternative.
+
+## Still failing
+
+Stop and ask the user for help.

--- a/skills/arize-admin/references/ax-setup.md
+++ b/skills/arize-admin/references/ax-setup.md
@@ -4,7 +4,7 @@ Consult this only when an `ax` command fails. Do NOT run these checks proactivel
 
 ## Check version first
 
-If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.14.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
+If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.19.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
 
 ## `ax: command not found`
 
@@ -19,7 +19,7 @@ If `ax` is installed (not `command not found`), always run `ax --version` before
 3. Install: `pip install arize-ax-cli`
 4. Add to PATH: `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
 
-## Version too old (below 0.14.0)
+## Version too old (below 0.19.0)
 
 Upgrade: `uv tool install --force --reinstall arize-ax-cli`, `pipx upgrade arize-ax-cli`, or `pip install --upgrade arize-ax-cli`
 

--- a/skills/arize-ai-provider-integration/references/ax-setup.md
+++ b/skills/arize-ai-provider-integration/references/ax-setup.md
@@ -4,7 +4,7 @@ Consult this only when an `ax` command fails. Do NOT run these checks proactivel
 
 ## Check version first
 
-If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.14.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
+If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.19.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
 
 ## `ax: command not found`
 
@@ -19,7 +19,7 @@ If `ax` is installed (not `command not found`), always run `ax --version` before
 3. Install: `pip install arize-ax-cli`
 4. Add to PATH: `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
 
-## Version too old (below 0.14.0)
+## Version too old (below 0.19.0)
 
 Upgrade: `uv tool install --force --reinstall arize-ax-cli`, `pipx upgrade arize-ax-cli`, or `pip install --upgrade arize-ax-cli`
 

--- a/skills/arize-annotation/references/ax-setup.md
+++ b/skills/arize-annotation/references/ax-setup.md
@@ -4,7 +4,7 @@ Consult this only when an `ax` command fails. Do NOT run these checks proactivel
 
 ## Check version first
 
-If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.14.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
+If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.19.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
 
 ## `ax: command not found`
 
@@ -19,7 +19,7 @@ If `ax` is installed (not `command not found`), always run `ax --version` before
 3. Install: `pip install arize-ax-cli`
 4. Add to PATH: `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
 
-## Version too old (below 0.14.0)
+## Version too old (below 0.19.0)
 
 Upgrade: `uv tool install --force --reinstall arize-ax-cli`, `pipx upgrade arize-ax-cli`, or `pip install --upgrade arize-ax-cli`
 

--- a/skills/arize-dataset/references/ax-setup.md
+++ b/skills/arize-dataset/references/ax-setup.md
@@ -4,7 +4,7 @@ Consult this only when an `ax` command fails. Do NOT run these checks proactivel
 
 ## Check version first
 
-If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.14.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
+If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.19.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
 
 ## `ax: command not found`
 
@@ -19,7 +19,7 @@ If `ax` is installed (not `command not found`), always run `ax --version` before
 3. Install: `pip install arize-ax-cli`
 4. Add to PATH: `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
 
-## Version too old (below 0.14.0)
+## Version too old (below 0.19.0)
 
 Upgrade: `uv tool install --force --reinstall arize-ax-cli`, `pipx upgrade arize-ax-cli`, or `pip install --upgrade arize-ax-cli`
 

--- a/skills/arize-evaluator/references/ax-setup.md
+++ b/skills/arize-evaluator/references/ax-setup.md
@@ -4,7 +4,7 @@ Consult this only when an `ax` command fails. Do NOT run these checks proactivel
 
 ## Check version first
 
-If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.14.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
+If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.19.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
 
 ## `ax: command not found`
 
@@ -19,7 +19,7 @@ If `ax` is installed (not `command not found`), always run `ax --version` before
 3. Install: `pip install arize-ax-cli`
 4. Add to PATH: `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
 
-## Version too old (below 0.14.0)
+## Version too old (below 0.19.0)
 
 Upgrade: `uv tool install --force --reinstall arize-ax-cli`, `pipx upgrade arize-ax-cli`, or `pip install --upgrade arize-ax-cli`
 

--- a/skills/arize-experiment/references/ax-setup.md
+++ b/skills/arize-experiment/references/ax-setup.md
@@ -4,7 +4,7 @@ Consult this only when an `ax` command fails. Do NOT run these checks proactivel
 
 ## Check version first
 
-If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.14.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
+If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.19.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
 
 ## `ax: command not found`
 
@@ -19,7 +19,7 @@ If `ax` is installed (not `command not found`), always run `ax --version` before
 3. Install: `pip install arize-ax-cli`
 4. Add to PATH: `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
 
-## Version too old (below 0.14.0)
+## Version too old (below 0.19.0)
 
 Upgrade: `uv tool install --force --reinstall arize-ax-cli`, `pipx upgrade arize-ax-cli`, or `pip install --upgrade arize-ax-cli`
 

--- a/skills/arize-prompt-optimization/references/ax-setup.md
+++ b/skills/arize-prompt-optimization/references/ax-setup.md
@@ -4,7 +4,7 @@ Consult this only when an `ax` command fails. Do NOT run these checks proactivel
 
 ## Check version first
 
-If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.14.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
+If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.19.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
 
 ## `ax: command not found`
 
@@ -19,7 +19,7 @@ If `ax` is installed (not `command not found`), always run `ax --version` before
 3. Install: `pip install arize-ax-cli`
 4. Add to PATH: `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
 
-## Version too old (below 0.14.0)
+## Version too old (below 0.19.0)
 
 Upgrade: `uv tool install --force --reinstall arize-ax-cli`, `pipx upgrade arize-ax-cli`, or `pip install --upgrade arize-ax-cli`
 

--- a/skills/arize-trace/references/ax-setup.md
+++ b/skills/arize-trace/references/ax-setup.md
@@ -4,7 +4,7 @@ Consult this only when an `ax` command fails. Do NOT run these checks proactivel
 
 ## Check version first
 
-If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.14.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
+If `ax` is installed (not `command not found`), always run `ax --version` before investigating further. The version must be `0.19.0` or higher — many errors are caused by an outdated install. If the version is too old, see **Version too old** below.
 
 ## `ax: command not found`
 
@@ -19,7 +19,7 @@ If `ax` is installed (not `command not found`), always run `ax --version` before
 3. Install: `pip install arize-ax-cli`
 4. Add to PATH: `$env:PATH = "$env:APPDATA\Python\Scripts;$env:PATH"`
 
-## Version too old (below 0.14.0)
+## Version too old (below 0.19.0)
 
 Upgrade: `uv tool install --force --reinstall arize-ax-cli`, `pipx upgrade arize-ax-cli`, or `pip install --upgrade arize-ax-cli`
 

--- a/tests/test_skill_selection.py
+++ b/tests/test_skill_selection.py
@@ -183,6 +183,37 @@ SPECIFIC_PROMPTS = [
         ["arize-compliance-audit"],
         ["specific", "compliance-audit"],
     ),
+    # arize-admin
+    (
+        "Invite jane@example.com to my Arize account with a member role",
+        ["arize-admin"],
+        ["specific", "admin"],
+    ),
+    (
+        "Create a new Arize space called team-alpha inside the Platform org",
+        ["arize-admin"],
+        ["specific", "admin"],
+    ),
+    (
+        "Generate a service API key scoped to the production space for my CI pipeline",
+        ["arize-admin"],
+        ["specific", "admin"],
+    ),
+    (
+        "Create a custom RBAC role with dataset and experiment permissions",
+        ["arize-admin"],
+        ["specific", "admin"],
+    ),
+    (
+        "Restrict a project so only users with explicit role bindings can access it",
+        ["arize-admin"],
+        ["specific", "admin"],
+    ),
+    (
+        "Offboard a user and revoke all their org and space memberships",
+        ["arize-admin"],
+        ["specific", "admin"],
+    ),
 ]
 
 # Single-skill: vague/ambiguous prompts (harder to route correctly)
@@ -311,6 +342,22 @@ VAGUE_PROMPTS = [
         "Help me make sure my AI meets regulatory requirements",
         ["arize-compliance-audit"],
         ["vague", "compliance-audit"],
+    ),
+    # Should route to arize-admin
+    (
+        "I need to control who can access my Arize projects",
+        ["arize-admin"],
+        ["vague", "admin"],
+    ),
+    (
+        "How do I set up my team in Arize?",
+        ["arize-admin"],
+        ["vague", "admin"],
+    ),
+    (
+        "I need a service account for my data pipeline",
+        ["arize-admin"],
+        ["vague", "admin"],
     ),
 ]
 


### PR DESCRIPTION
## Summary

- Adds `skills/arize-admin/` — a new skill covering the full admin surface of the `ax` CLI for enterprise access control
- Covers `ax users`, `ax organizations`, `ax spaces`, `ax roles`, `ax role-bindings`, `ax resource-restrictions`, and `ax api-keys`
- Includes six enterprise workflows: team onboarding, SAML/SSO role mapping, project restriction, access audit, user offboarding (with `ax users delete` cascade), and multi-tenant service key management
- Adds the skill to the README Available Skills table