### PR TITLE
remove dotenv from test harness, use explicit env var exports

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,0 @@
-# Arize Platform — get your key at https://app.arize.com/admin > API Keys
-ARIZE_API_KEY=
-ARIZE_SPACE_ID=
-# ARIZE_DEFAULT_PROJECT=
-
-# LLM Provider Keys (for ai-integrations, evaluators, prompt optimization)
-# OPENAI_API_KEY=
-# ANTHROPIC_API_KEY=

--- a/README.md
+++ b/README.md
@@ -116,6 +116,9 @@ export ARIZE_SPACE="my-workspace"        # name, or base64 ID like U3BhY2U6...
 ```bash
 export ARIZE_API_KEY="your-api-key"       # from https://app.arize.com/admin > API Keys
 export ARIZE_SPACE="my-workspace"         # space name or base64 ID from ax spaces list
+# export ARIZE_DEFAULT_PROJECT=my-project # optional default project
+# export OPENAI_API_KEY="sk-..."          # for AI integrations and evaluators
+# export ANTHROPIC_API_KEY="sk-ant-..."   # for AI integrations and evaluators
 ```
 
 ### Verify

--- a/README.md
+++ b/README.md
@@ -112,29 +112,10 @@ You'll also need a space name or ID. Find yours by running `ax spaces list -o js
 export ARIZE_SPACE="my-workspace"        # name, or base64 ID like U3BhY2U6...
 ```
 
-**Option B — `.env` file** (project-scoped credentials + provider keys):
-
-Copy the example and fill in your keys:
-```bash
-cp .env.example .env
-# Edit .env with your credentials
-```
-
-The `.env` file supports all credentials used by the skills:
-```bash
-ARIZE_API_KEY=your-api-key               # from https://app.arize.com/admin > API Keys
-ARIZE_SPACE=my-workspace             # space name or base64 ID from ax spaces list
-# ARIZE_DEFAULT_PROJECT=my-project       # optional default project
-# OPENAI_API_KEY=sk-...                  # for AI integrations and evaluators
-# ANTHROPIC_API_KEY=sk-ant-...           # for AI integrations and evaluators
-```
-
-Skills automatically load this file during their prerequisite check. The `.env` file is gitignored — never commit it.
-
-**Option C — Environment variables** (CI/CD):
+**Option B — Environment variables** (CI/CD):
 ```bash
 export ARIZE_API_KEY="your-api-key"       # from https://app.arize.com/admin > API Keys
-export ARIZE_SPACE="my-workspace"        # space name or base64 ID from ax spaces list
+export ARIZE_SPACE="my-workspace"         # space name or base64 ID from ax spaces list
 ```
 
 ### Verify
@@ -213,6 +194,17 @@ For interactive setup, `ax profiles create` also offers **Advanced → Single en
 ## Testing Skills
 
 `tests/run_skill.py` is an interactive test harness that runs a skill end-to-end using the Claude Agent SDK. It creates a temporary workspace, passes in your Arize credentials, and streams the agent's output.
+
+Export the required environment variables before running:
+
+```bash
+export ARIZE_API_KEY="your-api-key"       # from https://app.arize.com/admin > API Keys
+export ARIZE_SPACE="my-workspace"         # space name or base64 ID from ax spaces list
+export TEST_PROJECT_NAME="my-project"     # optional: Arize project for trace tests
+export TEST_MODEL="claude-sonnet-4-6"     # optional: Claude model override
+```
+
+Then run the harness:
 
 ```bash
 python tests/run_skill.py --skill arize-trace --prompt "Export trace abc123"

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ You'll also need a space name or ID. Find yours by running `ax spaces list -o js
 export ARIZE_SPACE="my-workspace"        # name, or base64 ID like U3BhY2U6...
 ```
 
-**Option B — Environment variables** (CI/CD):
+**Option B — Environment variables**:
 ```bash
 export ARIZE_API_KEY="your-api-key"       # from https://app.arize.com/admin > API Keys
 export ARIZE_SPACE="my-workspace"         # space name or base64 ID from ax spaces list

--- a/tests/compare_models.py
+++ b/tests/compare_models.py
@@ -17,10 +17,6 @@ import pathlib
 import sys
 from datetime import datetime
 
-from dotenv import load_dotenv
-
-load_dotenv(pathlib.Path(__file__).parent.parent / ".env")
-
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 from harness.skill_router import SkillSelectionRunner

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ Shared fixtures for skill tests.
 
 Key environment variables (set in CI or locally):
   ARIZE_API_KEY       - Arize API key
-  ARIZE_SPACE_ID      - Arize space ID
+  ARIZE_SPACE         - Arize space name or base64 ID
   TEST_PROJECT_NAME   - Arize project name for trace-related tests
   TEST_MODEL          - Claude model override (default: None = use SDK default)
   SKILL_TESTS_REPORT_DIR - Where to save JSON reports (default: test-results)
@@ -14,10 +14,6 @@ import pathlib
 import sys
 
 import pytest
-from dotenv import load_dotenv
-
-# Load .env from the repository root (parent of tests/)
-load_dotenv(pathlib.Path(__file__).parent.parent / ".env", override=True)
 
 # Remove CLAUDECODE so the SDK can spawn Claude Code subprocesses even when
 # tests are run from inside a Claude Code session (nested sessions are blocked

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -2,4 +2,3 @@ claude-agent-sdk>=0.1.48
 pytest>=8.0
 pytest-asyncio>=0.23
 pytest-timeout>=2.2
-python-dotenv>=1.0

--- a/tests/run_skill.py
+++ b/tests/run_skill.py
@@ -28,11 +28,6 @@ _tests_dir = pathlib.Path(__file__).resolve().parent
 if str(_tests_dir) not in sys.path:
     sys.path.insert(0, str(_tests_dir))
 
-from dotenv import load_dotenv
-
-# Load .env from the repository root (parent of tests/)
-load_dotenv(pathlib.Path(__file__).parent.parent / ".env")
-
 from harness.result import TestResult
 
 SKILLS_DIR = pathlib.Path(__file__).parent.parent / "skills"
@@ -252,17 +247,17 @@ Examples:
 
     # Validate environment
     arize_api_key = os.environ.get("ARIZE_API_KEY")
-    arize_space_id = os.environ.get("ARIZE_SPACE_ID")
+    arize_space = os.environ.get("ARIZE_SPACE")
     if not arize_api_key:
-        print("Error: ARIZE_API_KEY is not set. Add it to .env or export it.", file=sys.stderr)
+        print("Error: ARIZE_API_KEY is not set. Export it before running.", file=sys.stderr)
         sys.exit(1)
-    if not arize_space_id:
-        print("Error: ARIZE_SPACE_ID is not set. Add it to .env or export it.", file=sys.stderr)
+    if not arize_space:
+        print("Error: ARIZE_SPACE is not set. Export it before running.", file=sys.stderr)
         sys.exit(1)
 
     arize_env = {
         "ARIZE_API_KEY": arize_api_key,
-        "ARIZE_SPACE_ID": arize_space_id,
+        "ARIZE_SPACE": arize_space,
         "ARIZE_DEFAULT_PROJECT": os.environ.get("TEST_PROJECT_NAME", "skill-tests"),
         "PATH": os.environ.get("PATH", "") + ":" + os.path.expanduser("~/.local/bin"),
     }


### PR DESCRIPTION
## Summary

- Deletes `.env.example` (no longer needed)
- Removes `load_dotenv` calls from `conftest.py`, `run_skill.py`, and `compare_models.py`
- Drops `python-dotenv` from `tests/requirements.txt`
- Fixes `ARIZE_SPACE_ID` → `ARIZE_SPACE` in `run_skill.py`
- Updates README: removes `.env` as Option B for auth, adds explicit `export` instructions to the Testing Skills section