### PR TITLE
ci(skill-selection): pin actions/upload-artifact to v4 SHA

### DIFF
--- a/.github/workflows/skill-selection-tests.yml
+++ b/.github/workflows/skill-selection-tests.yml
@@ -55,7 +55,7 @@ jobs:
 
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: skill-selection-results
           path: tests/test-results/


### PR DESCRIPTION
## Summary

The `actions/upload-artifact@v4` reference in `.github/workflows/skill-selection-tests.yml` is unpinned, which the org's action-pinning policy rejects:

> The action `actions/upload-artifact@v4` is not allowed in Arize-ai/arize-skills because all actions must be pinned to a full-length commit SHA.

This caused the "Skill Selection Tests" workflow to fail at setup on every PR — the workflow bails in ~6s before any test code runs (see [history](https://github.com/Arize-ai/arize-skills/actions/workflows/skill-selection-tests.yml)). Recent PRs (#60, #61) merged despite the red check.

Pins to `ea165f8d65b6e75b540449e92b4886f43607fa02` — the current commit target of `v4` per `gh api repos/actions/upload-artifact/git/refs/tags/v4`. The same SHA-pinned style is already used for `actions/checkout` and `actions/setup-python` elsewhere in the file.

## Test plan

- [x] On this PR, the "Skill Selection Tests" workflow should now get past setup (it may still fail on real test failures, but those will be honest failures — not a workflow rejection)