### PR TITLE
docs(readme): fix marketplace name in /plugin install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Open up a Claude Code session and execute the following:
 
 ```
 /plugin marketplace add Arize-ai/arize-skills
-/plugin install arize-skills@Arize-ai-arize-skills 
+/plugin install arize-skills@arize-skills
 ```
 
 ## Prerequisites


### PR DESCRIPTION
## Summary

The README's Option 4 (Claude Code plugin) install snippet uses a marketplace name that doesn't exist:

```
/plugin install arize-skills@Arize-ai-arize-skills
```

Running this in Claude Code fails with:

```
Marketplace "Arize-ai-arize-skills" not found
```

The Claude Code plugin manager derives the marketplace name from the `name` field in `.claude-plugin/marketplace.json`, which is `arize-skills` — not the GitHub repo slug with `/` rewritten to `-`. So the working command is `arize-skills@arize-skills`.

This is a one-line README fix so Option 4 actually works for first-time users.

## Change

```diff
-/plugin install arize-skills@Arize-ai-arize-skills 
+/plugin install arize-skills@arize-skills
```

(Also drops the trailing space that was on the original line.)

## Verification

Reproduced and verified locally with an isolated `CLAUDE_CONFIG_DIR`:

- `/plugin marketplace add Arize-ai/arize-skills` → `Successfully added marketplace: arize-skills`
- `/plugin install arize-skills@Arize-ai-arize-skills` → `Marketplace "Arize-ai-arize-skills" not found`
- `/plugin install arize-skills@arize-skills` → `Installed arize-skills. Run /reload-plugins to apply.`

## Test plan

- [ ] In a fresh Claude Code session, run the two README commands as printed and confirm install succeeds.