### PR TITLE
fix(readme): correct 40+ agents link to vercel-labs/skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Skills that guide AI coding agents to help you add observability, run experiment
 
 These skills encode the workflows we've refined building the [Arize](https://arize.com) platform and helping teams debug LLM apps in production. They handle the `ax` CLI flags, data shape quirks, and multi-step recipes so you don't have to.
 
-Works with Cursor, Claude Code, Codex, Windsurf, and [40+ other agents](https://github.com/nicepkg/agent-skills).
+Works with Cursor, Claude Code, Codex, Windsurf, and [40+ other agents](https://github.com/vercel-labs/skills).
 
 ## New to Arize? Start Here
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Skills that guide AI coding agents to help you add observability, run experiment
 
 These skills encode the workflows we've refined building the [Arize](https://arize.com) platform and helping teams debug LLM apps in production. They handle the `ax` CLI flags, data shape quirks, and multi-step recipes so you don't have to.
 
-Works with Cursor, Claude Code, Codex, Windsurf, and [40+ other agents](https://github.com/vercel-labs/skills).
+Works with Cursor, Claude Code, Codex, Windsurf, and [40+ other agents](https://github.com/vercel-labs/skills#supported-agents).
 
 ## New to Arize? Start Here
 


### PR DESCRIPTION
## Summary

- Fix incorrect `nicepkg/agent-skills` link → `vercel-labs/skills`