### PR TITLE
feat: add GitHub Copilot as supported agent in installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Skills that guide AI coding agents to help you add observability, run experiment
 
 These skills encode the workflows we've refined building the [Arize](https://arize.com) platform and helping teams debug LLM apps in production. They handle the `ax` CLI flags, data shape quirks, and multi-step recipes so you don't have to.
 
-Works with Cursor, Claude Code, Codex, Windsurf, and [40+ other agents](https://github.com/nicepkg/agent-skills).
+Works with Cursor, Claude Code, Codex, GitHub Copilot, Windsurf, and [40+ other agents](https://github.com/nicepkg/agent-skills).
 
 ## New to Arize? Start Here
 
@@ -170,7 +170,7 @@ For interactive setup, `ax profiles create` also offers **Advanced → Single en
 | `--copy` | Copy files instead of symlinking |
 | `--force` | Overwrite existing skills |
 | `--skip-cli` | Don't install `ax` CLI even if missing |
-| `--agent <name>` | Manually specify agent (cursor, claude, codex) — repeatable |
+| `--agent <name>` | Manually specify agent (cursor, claude, codex, copilot) — repeatable |
 | `--skill <name>` | Only install/uninstall specific skills — repeatable (e.g. `--skill arize-trace --skill arize-dataset`) |
 | `--yes` | Skip confirmation prompts |
 | `--list` | List all available skills and exit |
@@ -185,7 +185,7 @@ For interactive setup, `ax profiles create` also offers **Advanced → Single en
 | `-Copy` | Copy files instead of symlinking |
 | `-Force` | Overwrite existing skills |
 | `-SkipCli` | Don't install `ax` CLI even if missing |
-| `-Agent <name>` | Manually specify agent (cursor, claude, codex) — repeatable |
+| `-Agent <name>` | Manually specify agent (cursor, claude, codex, copilot) — repeatable |
 | `-Skill <name>` | Only install/uninstall specific skills — repeatable |
 | `-Yes` | Skip confirmation prompts |
 | `-Uninstall` | Remove previously installed skill symlinks |

--- a/install.ps1
+++ b/install.ps1
@@ -67,19 +67,22 @@ if ($Skill.Count -gt 0) {
 function Get-AgentSkillsDir {
     param([string]$AgentName, [string]$Base)
     switch ($AgentName) {
-        "cursor" { Join-Path $Base ".cursor\skills" }
-        "claude" { Join-Path $Base ".claude\skills" }
-        "codex"  { Join-Path $Base ".codex\skills" }
-        default  { Join-Path $Base ".$AgentName\skills" }
+        "cursor"  { Join-Path $Base ".cursor\skills" }
+        "claude"  { Join-Path $Base ".claude\skills" }
+        "codex"   { Join-Path $Base ".codex\skills" }
+        "copilot" { Join-Path $Base ".agents\skills" }
+        default   { Join-Path $Base ".$AgentName\skills" }
     }
 }
 
 function Find-Agents {
     param([string]$Base)
     $found = @()
-    if (Test-Path (Join-Path $Base ".cursor")) { $found += "cursor" }
-    if (Test-Path (Join-Path $Base ".claude")) { $found += "claude" }
-    if (Test-Path (Join-Path $Base ".codex"))  { $found += "codex" }
+    if (Test-Path (Join-Path $Base ".cursor"))         { $found += "cursor" }
+    if (Test-Path (Join-Path $Base ".claude"))         { $found += "claude" }
+    if (Test-Path (Join-Path $Base ".codex"))          { $found += "codex" }
+    if ((Test-Path (Join-Path $Base ".github\copilot")) -or
+        (Get-Command gh -ErrorAction SilentlyContinue)) { $found += "copilot" }
     return $found
 }
 
@@ -109,12 +112,13 @@ if ($Agent.Count -gt 0) {
 
 if ($Agents.Count -eq 0) {
     if (-not $Yes) {
-        Write-Host "No agents detected (looked for .cursor/, .claude/, .codex/)."
+        Write-Host "No agents detected (looked for .cursor/, .claude/, .codex/, .github/copilot/ directories and cursor/claude/codex/gh binaries)."
         Write-Host ""
         Write-Host "Which agent(s) are you using?"
         Write-Host "  1) cursor"
         Write-Host "  2) claude"
         Write-Host "  3) codex"
+        Write-Host "  4) copilot (GitHub Copilot)"
         Write-Host ""
         $choices = Read-Host "Enter number(s) separated by spaces [1]"
         if (-not $choices) { $choices = "1" }
@@ -123,11 +127,12 @@ if ($Agents.Count -eq 0) {
                 "1" { $Agents += "cursor" }
                 "2" { $Agents += "claude" }
                 "3" { $Agents += "codex" }
+                "4" { $Agents += "copilot" }
                 default { Write-Host "Unknown choice: $choice"; exit 1 }
             }
         }
     } else {
-        Write-Host "No agents detected (looked for .cursor/, .claude/, .codex/)."
+        Write-Host "No agents detected (looked for .cursor/, .claude/, .codex/, .github/copilot/ directories and cursor/claude/codex/gh binaries)."
         Write-Host "Use -Agent <name> to specify manually, e.g.: .\install.ps1 -Agent cursor"
         exit 1
     }

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,7 @@ Flags:
   --copy            Copy files instead of symlinking
   --force           Overwrite existing skills with same names
   --skip-cli        Don't install ax CLI even if missing
-  --agent <name>    Manually specify agent (cursor, claude, codex) — repeatable
+  --agent <name>    Manually specify agent (cursor, claude, codex, copilot) — repeatable
   --skill <name>    Only install/uninstall specific skills — repeatable
   --yes             Skip confirmation prompts
   --uninstall       Remove previously installed skill symlinks
@@ -45,6 +45,7 @@ Examples:
   ./install.sh --project ~/my-app --skill arize-trace          # Install one skill
   ./install.sh --project . --skill arize-trace --skill arize-dataset  # Install two skills
   ./install.sh --project . --agent cursor --yes                # Current dir, Cursor only
+  ./install.sh --project . --agent copilot --yes               # Current dir, GitHub Copilot only
   ./install.sh --global                                        # Install globally
   ./install.sh --project ~/my-app --copy                       # Copy instead of symlink
   ./install.sh --project ~/my-app --uninstall                  # Remove all installed symlinks
@@ -105,10 +106,11 @@ AGENTS=()
 agent_skills_dir() {
   local agent="$1" base="$2"
   case "$agent" in
-    cursor) echo "$base/.cursor/skills" ;;
-    claude) echo "$base/.claude/skills" ;;
-    codex)  echo "$base/.codex/skills" ;;
-    *)      echo "$base/.$agent/skills" ;;
+    cursor)  echo "$base/.cursor/skills" ;;
+    claude)  echo "$base/.claude/skills" ;;
+    codex)   echo "$base/.codex/skills" ;;
+    copilot) echo "$base/.agents/skills" ;;
+    *)       echo "$base/.$agent/skills" ;;
   esac
 }
 
@@ -125,15 +127,17 @@ detect_agents() {
   local base="$1"
 
   # Check for config directories in the target project/home
-  if [[ -d "$base/.cursor" ]]; then add_agent "cursor"; fi
-  if [[ -d "$base/.claude" ]]; then add_agent "claude"; fi
-  if [[ -d "$base/.codex" ]];  then add_agent "codex"; fi
+  if [[ -d "$base/.cursor" ]];        then add_agent "cursor"; fi
+  if [[ -d "$base/.claude" ]];        then add_agent "claude"; fi
+  if [[ -d "$base/.codex" ]];         then add_agent "codex"; fi
+  if [[ -d "$base/.github/copilot" ]]; then add_agent "copilot"; fi
 
   # Also check for installed agent binaries (catches agents that haven't
   # created config dirs in this project yet)
   command -v cursor &>/dev/null && add_agent "cursor"
   command -v claude &>/dev/null && add_agent "claude"
   command -v codex  &>/dev/null && add_agent "codex"
+  command -v gh     &>/dev/null && add_agent "copilot"
 }
 
 if [[ "$GLOBAL" != true && -z "$PROJECT_DIR" ]]; then
@@ -152,12 +156,13 @@ fi
 
 if [[ ${#AGENTS[@]} -eq 0 ]]; then
   if [[ -t 0 && "$YES" != true ]]; then
-    echo "No agents detected (checked for .cursor/, .claude/, .codex/ directories and cursor/claude/codex binaries)."
+    echo "No agents detected (checked for .cursor/, .claude/, .codex/, .github/copilot/ directories and cursor/claude/codex/gh binaries)."
     echo ""
     echo "Which agent(s) are you using?"
     echo "  1) cursor"
     echo "  2) claude"
     echo "  3) codex"
+    echo "  4) copilot (GitHub Copilot)"
     echo ""
     read -rp "Enter number(s) separated by spaces [1]: " agent_choices
     agent_choices="${agent_choices:-1}"
@@ -166,11 +171,12 @@ if [[ ${#AGENTS[@]} -eq 0 ]]; then
         1) AGENTS+=("cursor") ;;
         2) AGENTS+=("claude") ;;
         3) AGENTS+=("codex") ;;
+        4) AGENTS+=("copilot") ;;
         *) echo "Unknown choice: $choice"; exit 1 ;;
       esac
     done
   else
-    echo "No agents detected (checked for .cursor/, .claude/, .codex/ directories and cursor/claude/codex binaries)."
+    echo "No agents detected (checked for .cursor/, .claude/, .codex/, .github/copilot/ directories and cursor/claude/codex/gh binaries)."
     echo "Use --agent <name> to specify manually, e.g.: ./install.sh --agent cursor"
     exit 1
   fi


### PR DESCRIPTION
## Summary

- Adds `copilot` as a first-class agent option alongside `cursor`, `claude`, and `codex`
- Skills are installed to `.agents/skills/`, which GitHub Copilot reads during coding agent sessions
- Auto-detection checks for `.github/copilot/` directory or `gh` binary
- Interactive menu now shows option 4 for GitHub Copilot when no agent is detected

## Changes

- `install.sh`: adds `copilot` to `agent_skills_dir`, `detect_agents`, and interactive menu
- `install.ps1`: same additions for Windows
- `README.md`: mentions GitHub Copilot in the "Works with" line and flag tables

Closes Arize-ai/arize#73784