### PR TITLE
fix: replace delete with revoke

### DIFF
--- a/skills/arize-admin/SKILL.md
+++ b/skills/arize-admin/SKILL.md
@@ -13,12 +13,12 @@ Programmatic management of Arize users, organizations, spaces, roles, permission
 
 > **Privilege requirement:** Most operations require **org-admin** or **account-admin** privileges. If commands return `403 Forbidden`, the authenticated profile lacks sufficient permissions.
 
-> **Destructive-action rule:** Commands that delete, remove, or irreversibly modify resources (`delete`, `remove-user`, `unrestrict`) require **explicit user confirmation before execution**. When a user asks you to perform one of these operations:
-> 1. Summarize exactly what will happen (e.g., "This will delete user jane@example.com and cascade-remove all their org/space memberships, API keys, and role bindings.")
+> **Destructive-action rule:** Commands that delete, revoke, remove, or irreversibly modify resources (`delete`, `revoke`, `remove-user`, `unrestrict`) require **explicit user confirmation before execution**. When a user asks you to perform one of these operations:
+> 1. Summarize exactly what will happen (e.g., "This will delete user jane@example.com and cascade-revoke their API keys and remove all their org/space memberships and role bindings.")
 > 2. Ask the user to confirm (use `AskUserQuestion`).
 > 3. Only after the user confirms, run the command with `--force` to skip the CLI's interactive prompt.
 >
-> Never run a `--force` deletion without confirming with the user first.
+> Never run a `--force` destructive command without confirming with the user first.
 
 ## When to Use
 
@@ -57,6 +57,13 @@ Ask before running any commands:
 - **Name and email** — for each user to invite
 - **Role** — `admin`, `member`, or `read-only` (present as options)
 - **Invite mode** — `email_link` (default), `temporary_password`, or `none`
+
+### Revoking or rotating an API key
+Ask before running any commands:
+- **Which key?** — run `ax api-keys list -o json` and present options by name and status; or ask for `KEY_ID`
+- **Revoke or rotate?** — `revoke` invalidates immediately; `refresh` issues a new key with the same scope (zero-downtime rotation)
+
+If the user says "delete" an API key, use `ax api-keys revoke` — there is no `delete` subcommand for API keys.
 
 ## Concepts
 
@@ -102,7 +109,7 @@ ax users create \
 ax users update USER_ID --full-name "Jane Smith"
 ax users update USER_ID --is-developer          # grant developer flag
 
-ax users delete USER_ID --force   # ⚠ confirm first — cascades: org/space memberships, API keys, role bindings
+ax users delete USER_ID --force   # ⚠ confirm first — cascades: org/space memberships, API key revocation, role bindings
 
 ax users resend-invitation USER_ID
 ax users reset-password USER_ID
@@ -244,7 +251,7 @@ ax api-keys create-service-key \
   --space-role member \
   --expires-at "2027-01-01T00:00:00"
 
-ax api-keys delete KEY_ID --force   # ⚠ confirm first
+ax api-keys revoke KEY_ID --force   # ⚠ confirm first — invalidates the key immediately
 
 # Zero-downtime rotation — revokes old key, issues new one with same scope
 ax api-keys refresh KEY_ID

--- a/skills/arize-admin/references/REFERENCE.md
+++ b/skills/arize-admin/references/REFERENCE.md
@@ -124,8 +124,11 @@ One service key per tenant space — scoped permissions, no org-admin required:
 ax api-keys create --name "tenant-acme-key" --key-type service --space "tenant-acme"
 ax api-keys create --name "tenant-beta-key" --key-type service --space "tenant-beta"
 
-# Rotate a key (zero-downtime, same scope)
+# Revoke a key (immediate invalidation)
 ax api-keys list --key-type service -o json   # find KEY_ID by name
+ax api-keys revoke KEY_ID --force
+
+# Rotate a key (zero-downtime, same scope)
 ax api-keys refresh KEY_ID
 ```
 
@@ -144,3 +147,4 @@ Service keys can only write traces to their scoped space — they cannot access 
 | Role create fails with duplicate name | Name already in use | Use `ax roles list --is-custom` to find the existing role |
 | Service key create fails | `--space` missing or space doesn't exist | Verify with `ax spaces list`; `--space` is required for service keys |
 | Key value not saved | Raw key was not captured at creation | Refresh the key: `ax api-keys refresh KEY_ID` |
+| `Unknown command delete` on `ax api-keys` | `delete` was removed; use `revoke` instead | `ax api-keys revoke KEY_ID --force` |

--- a/tests/test_skill_selection.py
+++ b/tests/test_skill_selection.py
@@ -216,6 +216,11 @@ SPECIFIC_PROMPTS = [
         ["specific", "admin"],
     ),
     (
+        "Revoke an expired API key in Arize",
+        ["arize-admin"],
+        ["specific", "admin"],
+    ),
+    (
         "Create a custom RBAC role with dataset and experiment permissions",
         ["arize-admin"],
         ["specific", "admin"],
@@ -383,6 +388,11 @@ VAGUE_PROMPTS = [
     ),
     (
         "I need a service account for my data pipeline",
+        ["arize-admin"],
+        ["vague", "admin"],
+    ),
+    (
+        "I need to remove a compromised API key from my Arize account",
         ["arize-admin"],
         ["vague", "admin"],
     ),


### PR DESCRIPTION
## Summary
Updates the `arize-admin` skill to match the ax CLI/API change: API keys are **revoked**, not deleted. The `ax api-keys delete` subcommand no longer exists — agents should use `ax api-keys revoke` instead.
- Replace `ax api-keys delete` with `ax api-keys revoke` in `SKILL.md` and `REFERENCE.md`
- Extend the destructive-action rule to include `revoke` and clarify that user offboarding cascade-revokes API keys
- Add upfront guidance for revoke vs. rotate workflows, including mapping user "delete" language to `revoke`
- Document revoke in Workflow 6 (multi-tenant service keys) and add a troubleshooting row for `Unknown command delete`
- Add skill-selection routing tests for revoke/remove API key prompts
## Context
The main codebase replaced the API key `/delete` endpoint with `/revoke`. This PR keeps the skills aligned so agents don't suggest the removed `delete` subcommand.
Other `delete` operations (`ax users delete`, `ax spaces delete`, etc.) are unchanged.
## Test plan
- [ ] `python scripts/validate_skills.py` passes
- [ ] Confirm `skills/arize-admin/SKILL.md` documents `ax api-keys revoke KEY_ID --force` with confirmation before `--force`
- [ ] Confirm no remaining `ax api-keys delete` references in the repo
- [ ] Optional: `pytest tests/test_skill_selection.py -k "Revoke or compromised" -v` (requires `ANTHROPIC_API_KEY`)