### PR TITLE
ci: pin release-please-action to full commit SHA

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json


### PR DESCRIPTION
## Problem

The `Release Please` workflow references the action by tag:

```yaml
- uses: googleapis/release-please-action@v4
```

The org enforces a policy that **all GitHub Actions must be pinned to a full-length commit SHA**. As a result, every run of this workflow since it was added (#69) has failed instantly with:

> The action googleapis/release-please-action@v4 is not allowed in Arize-ai/arize-skills because all actions must be pinned to a full-length commit SHA.

Because the job never runs, no release PR is ever opened and **no `v1.0.0` tag or GitHub release has ever been created**.

## Fix

Pin `googleapis/release-please-action` to the commit the `v4` tag resolves to (`5c625bfb5d1ff62eadeeb3772007f7f66fdcf071`), keeping the `# v4` comment for readability — consistent with how the other workflows in this repo (e.g. `skill-selection-tests.yml`) already pin their actions.

## After merge

Release Please will run on `main`, open a release PR, and merging that PR will cut the first `v1.0.0` tag + release — which we need as an immutable ref for the awesome-copilot external-plugin submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)