### PR TITLE
fix(arize-instrumentation): scope gate, consent, progress signaling, and handoff

### DIFF
--- a/skills/arize-instrumentation/SKILL.md
+++ b/skills/arize-instrumentation/SKILL.md
@@ -27,12 +27,13 @@ Then execute the two phases below.
 - **Follow existing code style** and project conventions.
 - **Keep output concise and production-focused** — do not generate extra documentation or summary files.
 - **NEVER embed literal credential values in generated code** — always reference environment variables (e.g., `os.environ["ARIZE_API_KEY"]`, `process.env.ARIZE_API_KEY`). This includes API keys, space IDs, and any other secrets. The user sets these in their own environment; the agent must never output raw secret values.
+- **Ask before creating persistent local state.** Do not create or update `ax` profiles, edit shell startup files (`.zshrc`/`.bashrc`), persist environment variables, or write memory/note files without explicit user consent. Prefer non-persistent verification (env vars set for the run, temp `--output-dir` exports); offer to persist only after the user approves (see references/ax-profiles.md § Save Credentials for Future Use).
 
 ## Phase 0: Environment preflight
 
 Before changing code:
 
-1. Confirm the repo/service scope is clear. For monorepos, do not assume the whole repo should be instrumented.
+1. **Confirm scope before touching anything.** Identify the exact target — service, entrypoint, framework, and tracing type. If it is ambiguous, do read-only inspection only and **ask the minimal scope question before installing packages or editing code** (see *When you must ask the user first*). Do not assume the whole repo, and do not pick a service or framework for the user.
 2. Identify the local runtime surface you will need for verification:
    - package manager and app start command
    - whether the app is long-running, server-based, or a short-lived CLI/script
@@ -47,6 +48,8 @@ If monorepo scope, service entrypoint, or target app is still unclear after quic
 1. Acknowledge the skill, e.g.: **I found the arize-instrumentation skill in this repo** (you may add `skills/arize-instrumentation/SKILL.md` if helpful).
 2. Then a clear pause line, e.g.: **A few clarifying questions before I invoke it:**
 3. Ask **minimal** numbered or short bullet questions — only what blocks Phase 1 or Phase 2.
+
+Cases that require a scope question before acting: a **monorepo** with several packages; **multiple deployable services** (e.g. an API and a worker); or **multiple LLM frameworks/entrypoints** in one codebase (e.g. a LangChain service alongside a raw-OpenAI script). Name the candidates you found and ask which to instrument.
 
 ## Phase 1: Analysis (read-only)
 
@@ -99,7 +102,7 @@ See references/integration-routing.md for the full list of supported integration
 
 ## Phase 2: Implementation
 
-Proceed **only after the user confirms** the Phase 1 analysis.
+Proceed **only after the user confirms** the Phase 1 analysis — and, when scope was ambiguous, only after the specific service/framework is confirmed.
 
 ### Steps
 
@@ -163,6 +166,27 @@ When verification is blocked by CLI or account issues, end with a concrete statu
 - latest local trace ID or run ID
 - whether exporter logs show local span emission
 - whether the failure is credential, space/project resolution, network, or collector rejection
+
+## Progress and status reporting
+
+Instrumentation spans several slow steps. Keep the user oriented:
+
+- Emit a short milestone at each checkpoint: **dependency install → tracing wiring → app run → trace export → verification**.
+- Summarize recovered errors in plain language and mark them **resolved** — do not present a recovered dependency/CLI error as if it were a blocker.
+- Don't make raw command output the primary status; quote only the decisive line when it matters.
+- End with a concise summary that separates **completed work** from any **remaining verification blockers**.
+
+## Next steps after verification
+
+Trace confirmation is the start of the observability workflow, not the end. After a confirmed trace, briefly offer the next relevant step based on the user's goal — keep it short and optional, not a pitch:
+
+- Inspect or debug traces → **`arize-trace`**
+- Curate examples into a dataset → **`arize-dataset`**
+- Add LLM-as-judge or code evaluators → **`arize-evaluator`**
+- Compare models or prompts on a test set → **`arize-experiment`**
+- Improve a prompt → **`arize-prompt-optimization`**
+
+If the trace has obvious quality issues, point to trace inspection/debugging (**`arize-trace`**) first, before suggesting downstream workflows.
 
 ## Emitting `session.id` for multi-turn session tracking
 

--- a/tests/test_skill_selection.py
+++ b/tests/test_skill_selection.py
@@ -271,6 +271,11 @@ VAGUE_PROMPTS = [
         ["arize-instrumentation"],
         ["vague", "instrumentation"],
     ),
+    (
+        "Help me instrument traces",
+        ["arize-instrumentation"],
+        ["vague", "instrumentation", "scope"],
+    ),
     # Should route to dataset
     (
         "I need some test data for my model",


### PR DESCRIPTION
## Summary
Improves the interaction flow of the **arize-instrumentation** skill. Addresses four assigned issues:

- **#80** — Strengthen the **scope gate**: identify the exact target (service, entrypoint, framework, tracing type) with read-only inspection first, and require an explicit scope answer **before installing packages or editing code** when the target is ambiguous (monorepo / multiple services / multiple frameworks). Reinforced at Phase 0, the "When you must ask" pattern, and the Phase 2 gate.
- **#79** — Hard Core-principle rule: **ask before creating persistent local state** (`ax` profiles, shell startup edits, persisted env vars, memory/note files). Prefer non-persistent verification; persist only on approval (defers to `ax-profiles.md § Save Credentials for Future Use`).
- **#87** — New **"Progress and status reporting"** section: milestone checkpoints (install → wiring → run → export → verify), recovered warnings vs active blockers, no raw-output dumps, concise closing summary.
- **#88** — New **"Next steps after verification"** handoff to the relevant adjacent skill (`arize-trace` / `arize-dataset` / `arize-evaluator` / `arize-experiment` / `arize-prompt-optimization`), routing to trace inspection first when the trace has quality issues.

## Approach
Kept additions tight and layered onto existing scope guidance rather than adding disconnected special-cases. Adds one skill-selection routing test for an unspecified-target instrumentation prompt.

Ran `/simplify`: collapsed the "don't install/edit to explore" injunction (was stated three times) to a single spot and tightened the progress intro. Confirmed the consent rule doesn't contradict `ax-profiles.md` (which writes shell files only behind its own consent gate) and that all five referenced sibling skills exist.

> Note: the ask-before-acting behavior can't be exercised by the routing-only skill-selection harness, so only a routing test is added. The "quality issues" handoff phrasing pairs with the post-verify checks in the companion PR #92.

> The *Skill Selection Tests* check is expected to fail — the repo's `ANTHROPIC_API_KEY` Actions secret is invalid/expired (separate infra issue), unrelated to these doc changes.

Closes #80, #79, #87, #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)