### PR TITLE
ci: install Claude Code CLI for skill selection tests

### DIFF
--- a/.github/workflows/skill-selection-tests.yml
+++ b/.github/workflows/skill-selection-tests.yml
@@ -25,6 +25,14 @@ jobs:
         with:
           python-version: "3.12"
 
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+
+      - name: Install Claude Code CLI
+        # The claude-agent-sdk harness drives the `claude` binary; it must be on PATH.
+        run: npm install -g @anthropic-ai/claude-code
+
       - name: Install test dependencies
         run: pip install -r tests/requirements.txt
 


### PR DESCRIPTION
## Problem

The **Skill Selection Tests** workflow has been failing on every branch and PR (and on manual `workflow_dispatch` runs). All ~90 tests fail identically — including negative prompts like *"What's the weather today?"* that touch no skill — with:

```
Exception: Claude Code returned an error result: success
CLI direct diagnostic: (diagnostic skipped: 'claude' binary not found in PATH)
```

The routing harness drives Claude Code via `claude-agent-sdk`, which spawns the `claude` binary. The workflow installs Python, pip deps, and the API key, but **never installs the Claude Code CLI**, so the SDK can't find it. (It last passed once before the SDK stopped providing the binary itself.)

## Fix

Add a SHA-pinned `setup-node` step and install the CLI globally so `claude` is on `PATH` before pytest runs:

```yaml
- uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
  with:
    node-version: "20"
- name: Install Claude Code CLI
  run: npm install -g @anthropic-ai/claude-code
```

The `setup-node` action is pinned to a full commit SHA to satisfy the org's action-pinning policy (the same policy that broke release-please earlier).

## ⚠️ Verified working, but a second (non-code) blocker remains

Running this on the PR confirms the fix works — the harness now gets **past** the missing-binary error and actually invokes Claude Code. That surfaced the true underlying failure, which is **billing, not code**:

```
API Error: 400 You have reached your specified workspace API usage limits.
You will regain access on 2026-08-01 at 00:00 UTC.
```

The `ANTHROPIC_API_KEY` repo secret belongs to a workspace over its usage limit, so all tests still fail (now for a billing reason). **This PR is still required** — without the CLI on PATH the suite can never run — but the check won't go green until the key limit is resolved: raise the workspace limit, swap in a key with budget, or wait until 2026-08-01. See the [comment below](https://github.com/Arize-ai/arize-skills/pull/96#issuecomment-4870874104) for detail.

## Scope

CI-only change; no skill or plugin content touched. Independent of #95 (the awesome-copilot quality-gate fixes) — that PR's failing check is this same pre-existing harness bug, and neither PR's check will go green until the API-key limit is lifted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)