### PR TITLE
fix(arize-evaluator): correct custom code evaluator import path and evaluate() signature

### DIFF
--- a/skills/arize-evaluator/SKILL.md
+++ b/skills/arize-evaluator/SKILL.md
@@ -221,7 +221,7 @@ Include a mapping for **every** variable the template references. Omitting one c
 ```bash
 ax tasks create-evaluation \
   --name "Hallucination Backfill" \
-  --task-type template_evaluation \
+  --task-type TEMPLATE_EVALUATION \
   --project PROJECT \
   --evaluators '[{"evaluator_id": "EVAL_ID", "column_mappings": {"input": "attributes.input.value", "output": "attributes.output.value"}}]' \
   --no-continuous
@@ -231,7 +231,7 @@ ax tasks create-evaluation \
 ```bash
 ax tasks create-evaluation \
   --name "Hallucination Monitor" \
-  --task-type template_evaluation \
+  --task-type TEMPLATE_EVALUATION \
   --project PROJECT \
   --evaluators '[{"evaluator_id": "EVAL_ID", "column_mappings": {"input": "attributes.input.value", "output": "attributes.output.value"}}]' \
   --is-continuous \
@@ -324,7 +324,7 @@ ax datasets export DATASET_NAME --space SPACE --stdout | python3 -c "import sys,
 ```bash
 ax tasks create-evaluation \
   --name "Experiment Correctness" \
-  --task-type template_evaluation \
+  --task-type TEMPLATE_EVALUATION \
   --dataset DATASET_NAME --space SPACE \
   --experiment-ids "EXP_ID" \   # base64 ID from `ax experiments list --space SPACE -o json`
   --evaluators '[{"evaluator_id": "EVAL_ID", "column_mappings": {"output": "output"}}]' \

--- a/skills/arize-evaluator/SKILL.md
+++ b/skills/arize-evaluator/SKILL.md
@@ -47,6 +47,8 @@ An **evaluator** is an LLM-as-judge definition. It contains:
 
 Evaluators are **versioned** — every prompt or model change creates a new immutable version. The most recent version is active.
 
+**Code evaluators** are the deterministic alternative — no AI integration or model, just Python. They run as a class subclassing `CodeEvaluator`, not a bare function, and have their own strict import-path and `evaluate()`-signature contract. Getting either wrong makes a run cancel silently at `0/0/0`. See "Custom Python code evaluators" in [references/cli-reference.md](references/cli-reference.md) before writing one.
+
 ### What is a Task?
 
 A **task** is how you run one or more evaluators against real data. Tasks are attached to a **project** (live traces/spans) or a **dataset** (experiment runs). A task contains:
@@ -422,6 +424,7 @@ The labels in `--classification-choices` must exactly match the labels reference
 | Run failed: "missing rails and classification choices" | Add `--classification-choices '{"label_a": 1, "label_b": 0}'` to `ax evaluators create-template-evaluator` — labels must match the template |
 | Run `completed`, all spans skipped | Query filter matched spans but column mappings are wrong or template variables don't resolve — export a sample span and verify paths |
 | `query_filter` set but 0 spans scored | The filter attribute may not be indexed in the eval index. `attributes.metadata.*` and custom attributes are often not indexed. Use `span_kind` or `attributes.llm.model_name` instead, or remove the filter to confirm spans exist in the window. |
+| Custom **code** evaluator run cancels ~3s with `0/0/0` (successes/errors/skipped) | Wrong import path or `evaluate()` signature — see the "CRITICAL" callout under **Custom Python code evaluators** in [references/cli-reference.md](references/cli-reference.md). Must import from `arize.experimental.datasets.experiments.evaluators.base` (not `arize.experiments`) and declare named `evaluate()` params, not just `**kwargs`. |
 
 ### Diagnosing cancelled runs
 

--- a/skills/arize-evaluator/references/cli-reference.md
+++ b/skills/arize-evaluator/references/cli-reference.md
@@ -104,39 +104,42 @@ Code evaluators run without an AI integration — they use deterministic logic (
 
 **Managed code evaluators** use built-in patterns:
 
+`--variables` is a JSON array of the input column names the check reads (e.g.
+`'["output"]'`). Any configuration the managed check needs — a regex pattern, a keyword
+list — goes through `--static-params`, not `--variables`.
+
 ```bash
-# Managed: check output matches a regex
+# Managed: check output is valid JSON
 ax evaluators create-code-evaluator \
   --name "JSON Format Check" \
   --space SPACE \
-  --template-name "json_format" \
   --commit-message "Initial version" \
   --code-type managed \
   --code-name "json_check" \
-  --managed-evaluator JSONParseable \
-  --variables '[]'
+  --managed-evaluator JSON_PARSEABLE \
+  --variables '["output"]'
 
 # Managed: check output contains required keywords
 ax evaluators create-code-evaluator \
   --name "Safety Keywords" \
   --space SPACE \
-  --template-name "safety_check" \
   --commit-message "Initial version" \
   --code-type managed \
   --code-name "safety_keywords" \
-  --managed-evaluator ContainsAnyKeyword \
-  --variables '[{"name": "keywords", "value": ["unsafe", "harmful", "illegal"]}]'
+  --managed-evaluator CONTAINS_ANY_KEYWORD \
+  --variables '["output"]' \
+  --static-params '[{"name": "keywords", "type": "STRING_ARRAY", "default_value": ["unsafe", "harmful", "illegal"]}]'
 ```
 
-**Managed evaluator types:**
+**Managed evaluator types** (pass the value exactly — the flag is case-sensitive):
 
 | Value | What it checks |
 |-------|---------------|
-| `MatchesRegex` | Output matches a regular expression |
-| `JSONParseable` | Output is valid JSON |
-| `ContainsAnyKeyword` | Output contains at least one keyword from a list |
-| `ContainsAllKeywords` | Output contains all keywords from a list |
-| `ExactMatch` | Output exactly equals a target string |
+| `MATCHES_REGEX` | Output matches a regular expression |
+| `JSON_PARSEABLE` | Output is valid JSON |
+| `CONTAINS_ANY_KEYWORD` | Output contains at least one keyword from a list |
+| `CONTAINS_ALL_KEYWORDS` | Output contains all keywords from a list |
+| `EXACT_MATCH` | Output exactly equals a target string |
 
 **Custom Python code evaluators:**
 
@@ -146,23 +149,23 @@ ax evaluators create-code-evaluator \
 > run **cancels in ~3 seconds with `num_successes=0`, `num_errors=0`, `num_skipped=0`** —
 > no error is surfaced, it just silently scores nothing.
 >
-> 1. **Import path.** The sandbox that executes the evaluator requires:
+> 1. **Import path.** The sandbox that executes the evaluator requires exactly this
+>    import — it is the only path the platform runtime exposes:
 >    ```python
 >    from arize.experimental.datasets.experiments.evaluators.base import (
 >        EvaluationResult,
 >        CodeEvaluator,
 >    )
 >    ```
->    NOT `arize.experiments` / `arize.experiments.evaluators.base`. That path exists in
->    the locally-installed `arize` (v8) SDK, so it imports fine and *looks* correct if
->    you test it locally — but the platform's runtime is a different namespace and does
->    not expose it. Always put imports in `--imports`, never inline in `--code`.
-> 2. **Named parameters on `evaluate()`, not just `**kwargs`.** The platform introspects
->    the named keyword parameters of `evaluate()` to build the list of variables shown
->    in the UI ("Add an arg for each data point you want to evaluate — mapped to dataset
->    columns or span attributes"). `def evaluate(self, **kwargs)` exposes **zero**
->    mappable variables, so the task matches 0 rows and cancels immediately. Name every
->    variable you need explicitly, with a default:
+>    Use it verbatim. A locally-installed `arize` SDK may expose other module paths that
+>    import fine on your machine but are absent on the platform, so passing a local test
+>    is not proof the import will resolve at run time. Always put imports in `--imports`,
+>    never inline in `--code`.
+> 2. **Named parameters on `evaluate()`, not just `**kwargs`.** The platform builds the
+>    list of mappable variables by introspecting the named keyword parameters of
+>    `evaluate()`. `def evaluate(self, **kwargs)` exposes **zero** mappable variables, so
+>    the task matches 0 rows and cancels immediately. Name every variable you need
+>    explicitly, with a default:
 >    ```python
 >    def evaluate(self, *, prediction=None, actual=None, **kwargs) -> EvaluationResult:
 >        ...
@@ -170,9 +173,7 @@ ax evaluators create-code-evaluator \
 >    ```
 >    Return `EvaluationResult`, not a bare `dict`. Each named parameter must exactly
 >    match an entry in `--variables` and, at the task level, a `column_mappings` key.
-> 3. **`--imports` vs `--code` are separate, like the UI's two panes.** The Arize UI has
->    distinct "Define Imports" and "Define Code Evaluator Class" sections — `--imports`
->    and `--code` map directly to them. `--code` must contain **only the class
+> 3. **`--imports` and `--code` are separate.** `--code` must contain **only the class
 >    definition** (no `import` statements inside it); all imports go in `--imports`.
 >
 > If a run still cancels at `0/0/0` after fixing the contract, confirm `num_skipped`
@@ -183,51 +184,128 @@ Static configuration (thresholds, keyword lists, regex patterns) that should NOT
 per row goes through `--static-params` and is read inside `evaluate()` as `self.<name>`
 — never declare these as named `evaluate()` parameters.
 
-```bash
-# Custom Python: inline code
-ax evaluators create-code-evaluator \
-  --name "Word Count Check" \
-  --space SPACE \
-  --template-name "word_count" \
-  --commit-message "Initial version" \
-  --code-type custom \
-  --code-name "word_count_eval" \
-  --variables '["prediction"]' \
-  --static-params '[{"name": "max_words", "type": "STRING", "default_value": "100"}]' \
-  --imports 'from arize.experimental.datasets.experiments.evaluators.base import (
+Write the import block and the class to their own files and pass each with `@filepath`.
+Loading from files keeps the class readable and avoids shell-quoting mistakes in the
+import block — prefer this for anything beyond a trivial evaluator.
+
+`my_evaluator_imports.py`:
+
+```python
+import json
+
+from arize.experimental.datasets.experiments.evaluators.base import (
     EvaluationResult,
     CodeEvaluator,
-)' \
-  --code 'class WordCountEval(CodeEvaluator):
+)
+```
+
+`my_evaluator.py` (class definition only — no imports):
+
+```python
+class JSONSchemaEval(CodeEvaluator):
     def evaluate(self, *, prediction=None, **kwargs) -> EvaluationResult:
-        max_words = int(self.max_words)
-        count = len((prediction or "").split())
-        passed = count <= max_words
+        # required_keys is a STRING_ARRAY static param -> a Python list
+        required_keys = self.required_keys or []
+        try:
+            parsed = json.loads(prediction or "")
+        except (TypeError, ValueError) as exc:
+            return EvaluationResult(
+                label="fail",
+                score=0.0,
+                explanation=f"output is not valid JSON: {exc}",
+            )
+        if not isinstance(parsed, dict):
+            return EvaluationResult(
+                label="fail",
+                score=0.0,
+                explanation="output JSON is not an object",
+            )
+        missing = [key for key in required_keys if key not in parsed]
+        passed = not missing
         return EvaluationResult(
             label="pass" if passed else "fail",
             score=float(passed),
-            explanation=f"{count} words (max {max_words})",
-        )'
+            explanation=(
+                "all required keys present"
+                if passed
+                else f"missing keys: {', '.join(missing)}"
+            ),
+        )
+```
 
-# Custom Python: from file (imports + class both loaded from disk)
+```bash
+# Custom Python (recommended): load imports + class from files
 ax evaluators create-code-evaluator \
-  --name "Custom Evaluator" \
+  --name "JSON Schema Check" \
   --space SPACE \
-  --template-name "custom_eval" \
   --commit-message "Initial version" \
   --code-type custom \
-  --code-name "my_eval" \
-  --variables '["prediction", "actual"]' \
+  --code-name "json_schema_eval" \
+  --variables '["prediction"]' \
+  --static-params '[{"name": "required_keys", "type": "STRING_ARRAY", "default_value": ["answer", "confidence"]}]' \
   --imports @./my_evaluator_imports.py \
   --code @./my_evaluator.py
+```
 
+You *can* inline both blocks instead, single-quoting each so the shell does not
+interpolate the Python — but for anything with its own imports or multiple branches
+like this, the file-based form above is easier to read and less error-prone:
+
+```bash
+# Custom Python (inline): workable, but harder to maintain than the file form
+ax evaluators create-code-evaluator \
+  --name "JSON Schema Check" \
+  --space SPACE \
+  --commit-message "Initial version" \
+  --code-type custom \
+  --code-name "json_schema_eval" \
+  --variables '["prediction"]' \
+  --static-params '[{"name": "required_keys", "type": "STRING_ARRAY", "default_value": ["answer", "confidence"]}]' \
+  --imports 'import json
+
+from arize.experimental.datasets.experiments.evaluators.base import (
+    EvaluationResult,
+    CodeEvaluator,
+)' \
+  --code 'class JSONSchemaEval(CodeEvaluator):
+    def evaluate(self, *, prediction=None, **kwargs) -> EvaluationResult:
+        required_keys = self.required_keys or []
+        try:
+            parsed = json.loads(prediction or "")
+        except (TypeError, ValueError) as exc:
+            return EvaluationResult(
+                label="fail",
+                score=0.0,
+                explanation=f"output is not valid JSON: {exc}",
+            )
+        if not isinstance(parsed, dict):
+            return EvaluationResult(
+                label="fail",
+                score=0.0,
+                explanation="output JSON is not an object",
+            )
+        missing = [key for key in required_keys if key not in parsed]
+        passed = not missing
+        return EvaluationResult(
+            label="pass" if passed else "fail",
+            score=float(passed),
+            explanation=(
+                "all required keys present"
+                if passed
+                else f"missing keys: {', '.join(missing)}"
+            ),
+        )'
+```
+
+```bash
 # Create a new version of a code evaluator
 ax evaluators create-code-evaluator-version NAME_OR_ID \
   --commit-message "Updated regex pattern" \
   --code-type managed \
   --code-name "regex_check" \
-  --managed-evaluator MatchesRegex \
-  --variables '[{"name": "pattern", "value": "^[A-Z]"}]'
+  --managed-evaluator MATCHES_REGEX \
+  --variables '["output"]' \
+  --static-params '[{"name": "pattern", "type": "REGEX", "default_value": "^[A-Z]"}]'
 ```
 
 **Key flags for `create-code-evaluator`:**
@@ -236,15 +314,14 @@ ax evaluators create-code-evaluator-version NAME_OR_ID \
 |------|----------|-------------|
 | `--name` | yes | Evaluator name (unique within space) |
 | `--space` | yes | Space name or ID to create in |
-| `--template-name` | yes | Eval column name — alphanumeric, spaces, hyphens, underscores |
 | `--commit-message` | yes | Description of this version |
 | `--code-type` | yes | `managed` (built-in pattern) or `custom` (Python class) |
-| `--code-name` | yes | Internal identifier for the code evaluator |
-| `--variables` | yes | For `custom`: JSON array of span-attribute/column names to pass into `evaluate()`, e.g. `'["prediction", "actual"]'` — each must match a named `evaluate()` parameter. For `managed`: JSON array of `{"name": "...", "value": ...}` definitions expected by that managed evaluator. |
-| `--managed-evaluator` | managed only | One of: `MatchesRegex`, `JSONParseable`, `ContainsAnyKeyword`, `ContainsAllKeywords`, `ExactMatch` |
+| `--code-name` | yes | Eval column name — alphanumeric, spaces, hyphens, underscores. (Code evaluators have **no** `--template-name` flag; that flag belongs to `create-template-evaluator`.) |
+| `--variables` | yes | JSON array of column/attribute names (strings), e.g. `'["prediction", "actual"]'`. For `custom`, each must match a named `evaluate()` parameter. For `managed`, these are the input columns the check reads — the check's own config (pattern, keyword list) goes in `--static-params`. |
+| `--managed-evaluator` | managed only | Case-sensitive; one of: `MATCHES_REGEX`, `JSON_PARSEABLE`, `CONTAINS_ANY_KEYWORD`, `CONTAINS_ALL_KEYWORDS`, `EXACT_MATCH` |
 | `--code` | custom only | Python source for the `CodeEvaluator` subclass only — no imports (or `@filepath` to read from file) |
 | `--imports` | custom only | Python import block for `--code`, e.g. the `arize.experimental.datasets.experiments.evaluators.base` import (or `@filepath`) |
-| `--static-params` | no | JSON array of static config parameters read via `self.<name>` inside `evaluate()`. Each item: `{"name": ..., "type": "STRING"\|"STRING_ARRAY"\|"REGEX", "default_value": "..."}` — `default_value` is always a string; cast numerics explicitly (`int(self.max_words)`) |
+| `--static-params` | no | JSON array of static config parameters read via `self.<name>` inside `evaluate()`. Each item: `{"name": ..., "type": "STRING"\|"STRING_ARRAY"\|"REGEX", "default_value": ...}` — `default_value` is a string for `STRING`/`REGEX` and an array of strings for `STRING_ARRAY`; cast numerics explicitly (e.g. `int(self.<name>)`) |
 | `--query-filter` | no | SQL-style filter to restrict which spans are evaluated |
 | `--description` | no | Human-readable description |
 | `--data-granularity` | no | `span` (default), `trace`, or `session` |
@@ -259,13 +336,13 @@ ax evaluators create-code-evaluator-version NAME_OR_ID \
 ax tasks list --space SPACE
 ax tasks list --project PROJECT_NAME
 ax tasks list --dataset DATASET_NAME --space SPACE
-ax tasks list --task-type template_evaluation   # filter by type: template_evaluation, code_evaluation, run_experiment
+ax tasks list --task-type TEMPLATE_EVALUATION   # filter by type: TEMPLATE_EVALUATION, CODE_EVALUATION, RUN_EXPERIMENT
 ax tasks get TASK_ID
 
 # Create evaluation task (project — continuous)
 ax tasks create-evaluation \
   --name "Correctness Monitor" \
-  --task-type template_evaluation \
+  --task-type TEMPLATE_EVALUATION \
   --project PROJECT_NAME \
   --evaluators '[{"evaluator_id": "EVAL_ID", "column_mappings": {"input": "attributes.input.value", "output": "attributes.output.value"}}]' \
   --is-continuous \
@@ -274,7 +351,7 @@ ax tasks create-evaluation \
 # Create evaluation task (project — one-time / backfill)
 ax tasks create-evaluation \
   --name "Correctness Backfill" \
-  --task-type template_evaluation \
+  --task-type TEMPLATE_EVALUATION \
   --project PROJECT_NAME \
   --evaluators '[{"evaluator_id": "EVAL_ID", "column_mappings": {"input": "attributes.input.value", "output": "attributes.output.value"}}]' \
   --no-continuous
@@ -282,7 +359,7 @@ ax tasks create-evaluation \
 # Create evaluation task (experiment / dataset)
 ax tasks create-evaluation \
   --name "Experiment Scoring" \
-  --task-type template_evaluation \
+  --task-type TEMPLATE_EVALUATION \
   --dataset DATASET_NAME --space SPACE \
   --experiment-ids "EXP_ID_1,EXP_ID_2" \   # base64 IDs from `ax experiments list --space SPACE -o json`
   --evaluators '[{"evaluator_id": "EVAL_ID", "column_mappings": {"output": "output"}}]' \

--- a/skills/arize-evaluator/references/cli-reference.md
+++ b/skills/arize-evaluator/references/cli-reference.md
@@ -140,6 +140,49 @@ ax evaluators create-code-evaluator \
 
 **Custom Python code evaluators:**
 
+> **CRITICAL — the class contract, not a bare function.** Custom code evaluators run
+> server-side as a Python **class that subclasses `CodeEvaluator`** — not a standalone
+> `def evaluate(...):` function. Get any of the three things below wrong and the task
+> run **cancels in ~3 seconds with `num_successes=0`, `num_errors=0`, `num_skipped=0`** —
+> no error is surfaced, it just silently scores nothing.
+>
+> 1. **Import path.** The sandbox that executes the evaluator requires:
+>    ```python
+>    from arize.experimental.datasets.experiments.evaluators.base import (
+>        EvaluationResult,
+>        CodeEvaluator,
+>    )
+>    ```
+>    NOT `arize.experiments` / `arize.experiments.evaluators.base`. That path exists in
+>    the locally-installed `arize` (v8) SDK, so it imports fine and *looks* correct if
+>    you test it locally — but the platform's runtime is a different namespace and does
+>    not expose it. Always put imports in `--imports`, never inline in `--code`.
+> 2. **Named parameters on `evaluate()`, not just `**kwargs`.** The platform introspects
+>    the named keyword parameters of `evaluate()` to build the list of variables shown
+>    in the UI ("Add an arg for each data point you want to evaluate — mapped to dataset
+>    columns or span attributes"). `def evaluate(self, **kwargs)` exposes **zero**
+>    mappable variables, so the task matches 0 rows and cancels immediately. Name every
+>    variable you need explicitly, with a default:
+>    ```python
+>    def evaluate(self, *, prediction=None, actual=None, **kwargs) -> EvaluationResult:
+>        ...
+>        return EvaluationResult(label=..., score=..., explanation=...)
+>    ```
+>    Return `EvaluationResult`, not a bare `dict`. Each named parameter must exactly
+>    match an entry in `--variables` and, at the task level, a `column_mappings` key.
+> 3. **`--imports` vs `--code` are separate, like the UI's two panes.** The Arize UI has
+>    distinct "Define Imports" and "Define Code Evaluator Class" sections — `--imports`
+>    and `--code` map directly to them. `--code` must contain **only the class
+>    definition** (no `import` statements inside it); all imports go in `--imports`.
+>
+> If a run still cancels at `0/0/0` after fixing the contract, confirm `num_skipped`
+> increments on the next run — that means the platform is now reaching and invoking
+> your evaluator (it may still skip rows for unrelated reasons, e.g. missing column data).
+
+Static configuration (thresholds, keyword lists, regex patterns) that should NOT vary
+per row goes through `--static-params` and is read inside `evaluate()` as `self.<name>`
+— never declare these as named `evaluate()` parameters.
+
 ```bash
 # Custom Python: inline code
 ax evaluators create-code-evaluator \
@@ -149,12 +192,24 @@ ax evaluators create-code-evaluator \
   --commit-message "Initial version" \
   --code-type custom \
   --code-name "word_count_eval" \
-  --variables '[{"name": "max_words", "value": 100}]' \
-  --code 'def evaluate(output, max_words):
-    count = len(output.split())
-    return {"label": "pass" if count <= max_words else "fail", "score": count}'
+  --variables '["prediction"]' \
+  --static-params '[{"name": "max_words", "type": "STRING", "default_value": "100"}]' \
+  --imports 'from arize.experimental.datasets.experiments.evaluators.base import (
+    EvaluationResult,
+    CodeEvaluator,
+)' \
+  --code 'class WordCountEval(CodeEvaluator):
+    def evaluate(self, *, prediction=None, **kwargs) -> EvaluationResult:
+        max_words = int(self.max_words)
+        count = len((prediction or "").split())
+        passed = count <= max_words
+        return EvaluationResult(
+            label="pass" if passed else "fail",
+            score=float(passed),
+            explanation=f"{count} words (max {max_words})",
+        )'
 
-# Custom Python: from file
+# Custom Python: from file (imports + class both loaded from disk)
 ax evaluators create-code-evaluator \
   --name "Custom Evaluator" \
   --space SPACE \
@@ -162,7 +217,8 @@ ax evaluators create-code-evaluator \
   --commit-message "Initial version" \
   --code-type custom \
   --code-name "my_eval" \
-  --variables '[]' \
+  --variables '["prediction", "actual"]' \
+  --imports @./my_evaluator_imports.py \
   --code @./my_evaluator.py
 
 # Create a new version of a code evaluator
@@ -182,13 +238,13 @@ ax evaluators create-code-evaluator-version NAME_OR_ID \
 | `--space` | yes | Space name or ID to create in |
 | `--template-name` | yes | Eval column name — alphanumeric, spaces, hyphens, underscores |
 | `--commit-message` | yes | Description of this version |
-| `--code-type` | yes | `managed` (built-in pattern) or `custom` (Python function) |
+| `--code-type` | yes | `managed` (built-in pattern) or `custom` (Python class) |
 | `--code-name` | yes | Internal identifier for the code evaluator |
-| `--variables` | yes | JSON array of variable definitions `[{"name": "...", "value": ...}]` |
+| `--variables` | yes | For `custom`: JSON array of span-attribute/column names to pass into `evaluate()`, e.g. `'["prediction", "actual"]'` — each must match a named `evaluate()` parameter. For `managed`: JSON array of `{"name": "...", "value": ...}` definitions expected by that managed evaluator. |
 | `--managed-evaluator` | managed only | One of: `MatchesRegex`, `JSONParseable`, `ContainsAnyKeyword`, `ContainsAllKeywords`, `ExactMatch` |
-| `--code` | custom only | Python code string (or `@filepath` to read from file) |
-| `--imports` | custom only | Python import block for the code |
-| `--static-params` | no | JSON of static parameters passed to the evaluator function |
+| `--code` | custom only | Python source for the `CodeEvaluator` subclass only — no imports (or `@filepath` to read from file) |
+| `--imports` | custom only | Python import block for `--code`, e.g. the `arize.experimental.datasets.experiments.evaluators.base` import (or `@filepath`) |
+| `--static-params` | no | JSON array of static config parameters read via `self.<name>` inside `evaluate()`. Each item: `{"name": ..., "type": "STRING"\|"STRING_ARRAY"\|"REGEX", "default_value": "..."}` — `default_value` is always a string; cast numerics explicitly (`int(self.max_words)`) |
 | `--query-filter` | no | SQL-style filter to restrict which spans are evaluated |
 | `--description` | no | Human-readable description |
 | `--data-granularity` | no | `span` (default), `trace`, or `session` |


### PR DESCRIPTION
## Summary
- The custom code evaluator guidance in `arize-evaluator` used a bare `def evaluate(output, ...)` function and the wrong import (`arize.experiments...`), which happens to resolve locally against the v8 SDK but is not the namespace the platform's code-eval runtime executes under (`arize.experimental.datasets.experiments.evaluators.base`).
- The skill also implied an `evaluate(self, **kwargs)` pattern. The platform introspects `evaluate()`'s named keyword parameters to build the variable-to-column mapping — `**kwargs` alone exposes zero mappable variables, so tasks resolve 0 rows and the run cancels in ~3s with `num_successes=0`, `num_errors=0`, `num_skipped=0` and no surfaced error.
- Rewrote `references/cli-reference.md`'s "Custom Python code evaluators" section with the correct `CodeEvaluator` subclass contract, corrected `--imports`/`--code`/`--variables`/`--static-params` flag semantics, and added a troubleshooting row + concepts pointer in `SKILL.md`.
- **Review follow-ups (Dirk):** removed the negative import-path example and all UI references from the agent-facing doc, and made the file-based (`@./file.py`) example the recommended form.
- **Additional accuracy fixes found while testing against `ax` v0.26.0** (each would break a user following the doc): code evaluators have no `--template-name` flag (only `--code-name`); `--managed-evaluator` values are case-sensitive UPPER_SNAKE (`MATCHES_REGEX`, `JSON_PARSEABLE`, …); managed `--variables` is an array of strings with config in `--static-params`, not `{"name","value"}` objects; `--task-type` is case-sensitive (`TEMPLATE_EVALUATION`, not `template_evaluation`).

Verified the corrected contract against the Arize monorepo's `CodeEvaluator` base class (`sdk/python/arize/v7/.../evaluators/base.py`) and the UI's code-eval scaffold generation prompt (`copilot/alyx/prompts/code_eval_prompt.py`), which is the source `ax skills sync` downloads this repo against.

Fixes: https://github.com/Arize-ai/arize/issues/75005

## Verification results

Measured whether an agent following the documented examples **verbatim** produces working, correct evaluators. Three evaluators, each on a hand-labeled, adversarial test set with independently-computed ground truth. **34/34 cases correct.**

| # | Evaluator (as documented) | Where it ran | Runtime result | Accuracy | Precision / Recall |
|---|---|---|---|---|---|
| 1 | **Custom** `JSONSchemaEval` (`STRING_ARRAY` param, JSON parse, 4 branches) | Local — class body verbatim | executes cleanly, returns `EvaluationResult` | **14/14 = 100%** | 1.00 / 1.00 |
| 2 | **Managed** `JSON_PARSEABLE` | Platform, end-to-end | `COMPLETED` — 10 successes / 0 errors / 0 skipped | **10/10 = 100%** | 1.00 / 1.00 |
| 3 | **Managed** `CONTAINS_ANY_KEYWORD` (`STRING_ARRAY` static param) | Platform, end-to-end | `COMPLETED` — 10 successes / 0 errors / 0 skipped | **10/10 = 100%** | 1.00 / 1.00 |

Test sets were adversarial, not happy-path: #1 covered malformed JSON, arrays, scalars, `null`, and missing/extra keys; #2 mixed valid scalars/arrays with truncated and garbage strings; #3 covered single- and multi-keyword hits plus clean negatives.

**What this confirms:**
- The custom `JSONSchemaEval` example is correct across every branch — `STRING_ARRAY → self.required_keys` (list) access, JSON error handling, and non-object rejection all behave as intended.
- The corrected managed forms actually run on the platform (`10/0/0` each), confirming the case-fixed enums and the `--variables`-as-string-array + `--static-params` config path — the doc's previous form was rejected at creation.

**Caveat — `REGEX` static param unverified:** the `create-code-evaluator-version` example uses a `REGEX`-type static param. A `MATCHES_REGEX` evaluator *creates* fine, but a run against it errored on every row (`num_errors=17, num_successes=0`), whereas the `STRING`- and `STRING_ARRAY`-typed params ran flawlessly. The correct shape for a `REGEX` static param at run time is not yet confirmed — treat that one example as unverified pending a follow-up.

**Environment limitation:** custom code evals are feature-gated off on the test account (`400: Custom code evals are not available for your account`), so the custom-code path (#1) is validated by executing the exact documented class body against ground truth rather than a platform run; the managed runs (#2, #3) exercise the task/experiment/column-mapping pipeline end-to-end.

## Test plan
- [x] Follow the updated `cli-reference.md` examples to create code evaluators via `ax evaluators create-code-evaluator` (managed end-to-end; custom is account-gated)
- [x] Create `code_evaluation` tasks against experiments with matching `column_mappings` — resolved all rows
- [x] Confirm documented evaluators produce correct results vs ground truth — 34/34 across the three
- [ ] Re-run the custom-code path end-to-end on an account with custom code evals enabled
- [ ] Confirm the correct `REGEX` static-param shape for a `MATCHES_REGEX` run
