### PR TITLE
Single-install hero prompt for onboarding

### DIFF
--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -3,8 +3,8 @@
 This file is the playbook a coding agent follows when a user pastes the Arize
 hero prompt:
 
-> Install the Arize skills from https://github.com/Arize-ai/arize-skills and use
-> them to add Arize tracing to this application following best practices.
+> Install Arize skills from https://github.com/Arize-ai/arize-skills and use the
+> arize-instrumentation skill to add tracing to this application.
 
 Goal: **one prompt → skills installed → app instrumented → a trace visible in
 Arize AX**, with the fewest possible interruptions. Run the whole flow in a
@@ -36,7 +36,7 @@ is expected; you do not need to act on them. When it finishes, the skills are
 available in this project — most relevant here is `arize-instrumentation`.
 
 If `npx` is unavailable, fall back to the git-clone installer documented in
-README.md ("Option 2: git clone"). Do not block on this — pick whichever install
+README.md ("Option 3: git clone"). Do not block on this — pick whichever install
 path works in the current environment and continue.
 
 ## Step 2 — Instrument the app

--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -1,0 +1,117 @@
+# Agent Install Playbook
+
+This file is the playbook a coding agent follows when a user pastes the Arize
+hero prompt:
+
+> Install the Arize skills from https://github.com/Arize-ai/arize-skills and use
+> them to add Arize tracing to this application following best practices.
+
+Goal: **one prompt → skills installed → app instrumented → a trace visible in
+Arize AX**, with the fewest possible interruptions. Run the whole flow in a
+single agent session. Only two things require the user: their Arize credentials,
+and a confirmation of the code changes before you apply them.
+
+This document is written to be read by an AI agent, not rendered in a browser.
+URLs are literal text; there are no clickable links.
+
+## Step 1 — Install the skills (non-interactive)
+
+Run the install with defaults so the user is never sent through the wizard:
+
+```bash
+npx skills add Arize-ai/arize-skills --skill "*" --yes
+```
+
+What the flags do, and why these defaults are safe here:
+
+- `--skill "*"` — install all Arize skills. These are first-party Arize skills,
+  so there is no reason to make the user hand-pick a subset up front.
+- `--yes` — accept the defaults and skip the confirmation prompts, including the
+  security summary. Acceptable because every skill is first-party Arize content.
+- Agent is **auto-detected** (Cursor, Claude Code, Codex, Copilot, Windsurf, …)
+  and skills are symlinked into the **current project** — no scope question.
+
+The CLI still prints its own installation / security / completion screens. That
+is expected; you do not need to act on them. When it finishes, the skills are
+available in this project — most relevant here is `arize-instrumentation`.
+
+If `npx` is unavailable, fall back to the git-clone installer documented in
+README.md ("Option 2: git clone"). Do not block on this — pick whichever install
+path works in the current environment and continue.
+
+## Step 2 — Instrument the app
+
+Invoke the **`arize-instrumentation`** skill and follow its two-phase flow. Do
+not re-derive instrumentation from scratch — the skill encodes the correct
+package names, import order, project-name resource attribute, and per-language
+setup. See `skills/arize-instrumentation/SKILL.md`.
+
+In brief, the skill will:
+
+1. **Phase 0 / 1 (read-only analysis):** detect language, package manager, LLM
+   providers, frameworks, and any existing OTel setup. It scopes the target
+   service (asking you only if a monorepo or entrypoint is genuinely ambiguous),
+   then returns a short summary of what it proposes to change.
+2. **User confirmation:** the user confirms the Phase 1 summary before any code
+   is written. This is the one instrumentation checkpoint we keep by design — do
+   not skip it.
+3. **Phase 2 (implementation):** install the instrumentation packages, create a
+   centralized instrumentation module initialized before any LLM client, and
+   reference credentials via environment variables only. Never embed literal
+   secret values in generated code.
+
+## Step 3 — Credentials (the one input that can't be eliminated)
+
+The app cannot send traces without an Arize **API key** and **space**. Let the
+`arize-instrumentation` skill drive this — it checks for an existing `ax` profile
+before asking the user to create one. In short:
+
+- Check for an existing profile: `ax profiles show` (and `ax profiles validate`).
+- If none exists, ask the user to run `ax profiles create` (interactive wizard),
+  or `ax auth login` for browser-based OAuth (do not run `ax auth login`
+  yourself — it opens a browser).
+- If `ax` is not installed, see the Prerequisites section of README.md.
+
+Never read `.env` files for secrets, and never print raw credential values.
+
+## Step 4 — Verify a trace landed
+
+Instrumentation is only "done" when a span actually reaches Arize:
+
+1. Run the app (or trigger one real request) so it makes at least one LLM call.
+2. Use the **`arize-trace`** skill to confirm the trace arrived, with the
+   expected `openinference.span.kind`, `input.value` / `output.value`, and
+   parent-child structure.
+3. For CLI / short-lived scripts, make sure spans are flushed before exit
+   (`force_flush()` then `shutdown()`), or they will never leave the process.
+
+## Edge cases — don't strand the user
+
+The hero prompt promises "one paste → traces." When it can't go cleanly, say so
+plainly and give the user the next action:
+
+- **Can't instrument** (unsupported language/framework, unclear monorepo scope,
+  no obvious entrypoint): state exactly what's blocking, ask the one question
+  that unblocks you, and point to https://arize.com/docs/ax/integrations for the
+  manual path. Do not guess and silently instrument the wrong service.
+- **Partial success** (skills installed but instrumentation failed midway):
+  report what succeeded, what's left, and the exact next step — never leave the
+  user with no traces and no next action.
+- **Verification fails** (code applied but no spans arrive): distinguish the
+  cause instead of retrying blindly — wrong/expired credentials, missing project
+  name resource attribute (HTTP 500), exporter not flushed, no traffic yet, or a
+  network/collector issue. The Verification section of
+  `skills/arize-instrumentation/SKILL.md` has the full triage checklist.
+
+## Path 1 fallback — skills only, no agent
+
+When there is no coding agent to paste this prompt into — CI pipelines, Docker
+builds, headless SSH sessions — use the plain one-liner:
+
+```bash
+npx skills add Arize-ai/arize-skills --skill "*" --yes
+```
+
+This installs the skills but does **not** instrument the app or send a trace
+(editing app code needs an agent). A human or agent still has to complete Steps
+2–4 later to get a trace flowing.

--- a/AGENT-INSTALL.md
+++ b/AGENT-INSTALL.md
@@ -62,28 +62,55 @@ In brief, the skill will:
 
 ## Step 3 — Credentials (the one input that can't be eliminated)
 
-The app cannot send traces without an Arize **API key** and **space**. Let the
-`arize-instrumentation` skill drive this — it checks for an existing `ax` profile
-before asking the user to create one. In short:
+The app cannot send traces without an Arize **API key** and **space**. Prefer
+the simplest path that already works for the user. Do **not** require the `ax`
+CLI to finish onboarding.
 
-- Check for an existing profile: `ax profiles show` (and `ax profiles validate`).
-- If none exists, ask the user to run `ax profiles create` (interactive wizard),
-  or `ax auth login` for browser-based OAuth (do not run `ax auth login`
-  yourself — it opens a browser).
-- If `ax` is not installed, see the Prerequisites section of README.md.
+In order:
+
+1. If `ARIZE_API_KEY` and `ARIZE_SPACE` (or `ARIZE_SPACE_ID`) are already set in
+   the environment (or the user will set them), use those. Generated code must
+   read env vars only — never embed literal secrets.
+2. If they want a persistent CLI profile and `ax` is installed, use
+   `ax profiles show` / `ax profiles create` / `ax auth login` (do not run
+   `ax auth login` yourself — it opens a browser).
+3. If `ax` is missing and env vars are enough for the app, continue. Only
+   suggest installing `ax` if the user wants CLI profile setup or CLI-based
+   verification later.
 
 Never read `.env` files for secrets, and never print raw credential values.
 
 ## Step 4 — Verify a trace landed
 
-Instrumentation is only "done" when a span actually reaches Arize:
+"Done" for first-trace onboarding means: instrumentation is in place, the app
+ran at least one LLM call, spans flushed, and the user has a clear way to see
+the trace in Arize. Prefer the lightest verification path — do **not** install
+`ax`, write custom SpanProcessor capture scripts, or wait on time-range export
+lag unless needed.
 
-1. Run the app (or trigger one real request) so it makes at least one LLM call.
-2. Use the **`arize-trace`** skill to confirm the trace arrived, with the
-   expected `openinference.span.kind`, `input.value` / `output.value`, and
-   parent-child structure.
-3. For CLI / short-lived scripts, make sure spans are flushed before exit
-   (`force_flush()` then `shutdown()`), or they will never leave the process.
+Verification ladder (stop at the first that succeeds):
+
+1. **Run the app** and trigger at least one real LLM call. For CLI/scripts,
+   ensure flush before exit (`force_flush()` then `shutdown()`), or spans never
+   leave the process.
+2. **Prefer a known `trace_id`:** if the app logs one, or you can add a single
+   temporary log line for the root span's trace ID, use that for a
+   deterministic check. Do not invent scratchpad exporters or custom OTel
+   processors to "capture" IDs.
+3. **Arize UI is a valid verify:** tell the user the project name and where to
+   look (recent root CHAIN / agent spans with tools). UI confirm is enough to
+   call onboarding successful when `ax` is not installed.
+4. **Optional CLI verify** (only if `ax` is already installed, or the user
+   explicitly wants it): use the `arize-trace` skill with
+   `ax spans export PROJECT --trace-id TRACE_ID`. Never use time-range queries
+   (`--days`, `--start-time`) to verify a trace from seconds ago — that index
+   lags **6–12 hours** and will false-negative. If you only have a time window,
+   say so and point the user at the UI instead of looping on empty exports.
+
+If verification is blocked, end with a concrete status: app instrumentation
+status, whether flush succeeded, latest local `trace_id` if any, and whether
+the blocker is credentials, project name, network/collector, or missing CLI —
+not another unverified install attempt.
 
 ## Edge cases — don't strand the user
 
@@ -100,8 +127,10 @@ plainly and give the user the next action:
 - **Verification fails** (code applied but no spans arrive): distinguish the
   cause instead of retrying blindly — wrong/expired credentials, missing project
   name resource attribute (HTTP 500), exporter not flushed, no traffic yet, or a
-  network/collector issue. The Verification section of
-  `skills/arize-instrumentation/SKILL.md` has the full triage checklist.
+  network/collector issue. Do **not** treat "ax not installed" or empty
+  time-range exports (6–12h lag) as proof spans failed. The Verification
+  section of `skills/arize-instrumentation/SKILL.md` has the full triage
+  checklist.
 
 ## Path 1 fallback — skills only, no agent
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,19 @@ Works with Cursor, Claude Code, Codex, GitHub Copilot, Windsurf, and [40+ other 
 
 ## New to Arize? Start Here
 
-**Adding tracing to your app** — give your coding agent this prompt:
+**One prompt, from nothing to a trace.** Give your coding agent (Cursor, Claude Code, Codex, …) this single prompt:
 
-> Follow the instructions from https://arize.com/docs/PROMPT.md and ask me questions as needed.
+> Install the Arize skills from https://github.com/Arize-ai/arize-skills and use them to add Arize tracing to this application following best practices.
 
-This walks through a two-phase flow: analyze your codebase for LLM providers and frameworks, then add Arize AX tracing with the right instrumentors. No skill installation needed.
+That's it. The agent installs the skills non-interactively, analyzes your codebase, adds the right instrumentation, and verifies a trace lands in Arize AX — all in one session. The only things it needs from you are your Arize credentials (`ax profiles create`) and a quick confirmation of the code changes before it applies them.
+
+Under the hood the agent follows [AGENT-INSTALL.md](AGENT-INSTALL.md), which runs the non-interactive install (`npx skills add Arize-ai/arize-skills --skill "*" --yes`) and then drives the `arize-instrumentation` skill end-to-end.
+
+**No coding agent?** (CI, Docker builds, headless SSH.) Install the skills with the one-liner below — note this installs skills only and does not instrument your app or send a trace:
+
+```bash
+npx skills add Arize-ai/arize-skills --skill "*" --yes
+```
 
 **Already have traces?** Give your agent this prompt to install the skills and start debugging:
 
@@ -20,19 +28,25 @@ This walks through a two-phase flow: analyze your codebase for LLM providers and
 
 ## Installation
 
-### Option 1: npx (recommended)
+### Option 1: Agent hero prompt (recommended)
+
+The primary path — installs the skills *and* instruments your app in one agent session. Paste into any coding agent:
+
+> Install the Arize skills from https://github.com/Arize-ai/arize-skills and use them to add Arize tracing to this application following best practices.
+
+See [AGENT-INSTALL.md](AGENT-INSTALL.md) for the exact flow the agent follows.
+
+### Option 2: npx one-liner (skills only)
+
+A single non-interactive command that installs all skills with auto-detected defaults. Use it in CI, Docker builds, or headless environments where no agent is available to run the hero prompt — it installs skills but does **not** instrument your app:
 
 ```bash
-# Interactive — choose skills, agent, and scope
-npx skills add Arize-ai/arize-skills
-
-# Non-interactive — install everything with auto-detected defaults
 npx skills add Arize-ai/arize-skills --skill "*" --yes
 ```
 
-Both options auto-detect your agent (Cursor, Claude Code, Codex, etc.) and symlink skills into place.
+`--skill "*"` installs every skill, `--yes` accepts defaults (agent auto-detected, current-project scope, security summary skipped). Drop both flags for the interactive wizard.
 
-### Option 2: git clone
+### Option 3: git clone
 
 **macOS / Linux:**
 ```bash
@@ -50,7 +64,7 @@ cd arize-skills
 
 The installer detects installed agents and optionally installs the `ax` CLI. Use `--global` / `-Global` instead to install to `~/.<agent>/skills/`.
 
-### Option 3: ax CLI
+### Option 4: ax CLI
 
 If you already have `ax` installed (v0.9.0+):
 
@@ -58,7 +72,7 @@ If you already have `ax` installed (v0.9.0+):
 ax skills install
 ```
 
-### Option 4: Claude Code plugin
+### Option 5: Claude Code plugin
 
 Open up a Claude Code session and execute the following:
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ Works with Cursor, Claude Code, Codex, GitHub Copilot, Windsurf, and [40+ other 
 
 **One prompt, from nothing to a trace.** Give your coding agent (Cursor, Claude Code, Codex, …) this single prompt:
 
-> Install the Arize skills from https://github.com/Arize-ai/arize-skills and use them to add Arize tracing to this application following best practices.
+> Install Arize skills from https://github.com/Arize-ai/arize-skills and use the arize-instrumentation skill to add tracing to this application.
 
-That's it. The agent installs the skills non-interactively, analyzes your codebase, adds the right instrumentation, and verifies a trace lands in Arize AX — all in one session. The only things it needs from you are your Arize credentials (`ax profiles create`) and a quick confirmation of the code changes before it applies them.
+That's it. The agent installs the skills non-interactively, analyzes your codebase, adds the right instrumentation, and verifies a trace lands in Arize AX — all in one session. The only things it needs from you are Arize credentials (API key and space — environment variables or `ax profiles create`) and a quick confirmation of the code changes before it applies them.
 
 Under the hood the agent follows [AGENT-INSTALL.md](AGENT-INSTALL.md), which runs the non-interactive install (`npx skills add Arize-ai/arize-skills --skill "*" --yes`) and then drives the `arize-instrumentation` skill end-to-end.
 
@@ -32,7 +32,7 @@ npx skills add Arize-ai/arize-skills --skill "*" --yes
 
 The primary path — installs the skills *and* instruments your app in one agent session. Paste into any coding agent:
 
-> Install the Arize skills from https://github.com/Arize-ai/arize-skills and use them to add Arize tracing to this application following best practices.
+> Install Arize skills from https://github.com/Arize-ai/arize-skills and use the arize-instrumentation skill to add tracing to this application.
 
 See [AGENT-INSTALL.md](AGENT-INSTALL.md) for the exact flow the agent follows.
 


### PR DESCRIPTION
## Summary

Path 2 onboarding: one agent prompt installs Arize skills non-interactively and drives instrumentation end-to-end.

- Adds `AGENT-INSTALL.md` — agent-readable playbook (install via `npx skills add ... --skill "*" --yes`, then `arize-instrumentation`, verify traces)
- Updates README to promote the hero prompt as the primary install path; npx one-liner remains the skills-only fallback for CI/headless

**Hero prompt:**
> Install Arize skills from https://github.com/Arize-ai/arize-skills and use the arize-instrumentation skill to add tracing to this application.

## How to test

1. Open a test LLM app repo in Cursor or Claude Code
2. Paste the hero prompt above
3. Provide Arize credentials (env vars or `ax profiles create`) when asked
4. Confirm the instrumentation Phase 1 summary, then run the app
5. Confirm: skills in `.cursor/skills` (or agent equivalent), trace visible in Arize AX

**Skills-only fallback (no agent):**
```bash
npx skills add Arize-ai/arize-skills --skill "*" --yes
```

## Test plan

- [ ] Hero prompt end-to-end in Cursor with a Python LLM app
- [ ] Hero prompt end-to-end in Claude Code
- [ ] `npx ... --skill "*" --yes` skips wizard (skills, agents, scope, security summary)
- [ ] Instrumentation Phase 1 confirm still gates code changes
- [ ] Verification succeeds via UI or trace_id without requiring `ax` CLI