### PR TITLE
feat(arize-span-routing): add skill for multi-space destination routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ For interactive setup, `ax profiles create` also offers **Advanced → Single en
 |-------|-------------|
 | [arize-trace](skills/arize-trace/SKILL.md) | Export traces and spans by trace ID, span ID, or session ID. Debug LLM application issues. |
 | [arize-instrumentation](skills/arize-instrumentation/SKILL.md) | Add Arize AX tracing to an app. Two-phase flow: analyze codebase, then implement instrumentation (uses [Agent-Assisted Tracing](https://arize.com/docs/ax/alyx/tracing-assistant)). |
+| [arize-span-routing](skills/arize-span-routing/SKILL.md) | Route Python spans from custom agent builders or multi-tenant apps to different Arize spaces and projects using application metadata. |
 | [arize-dataset](skills/arize-dataset/SKILL.md) | Create, manage, and download datasets and examples. |
 | [arize-experiment](skills/arize-experiment/SKILL.md) | Run and analyze experiments against datasets. |
 | [arize-evaluator](skills/arize-evaluator/SKILL.md) | Create LLM-as-judge evaluators, run evaluation tasks, and set up continuous monitoring. |

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ For interactive setup, `ax profiles create` also offers **Advanced → Single en
 |-------|-------------|
 | [arize-trace](skills/arize-trace/SKILL.md) | Export traces and spans by trace ID, span ID, or session ID. Debug LLM application issues. |
 | [arize-instrumentation](skills/arize-instrumentation/SKILL.md) | Add Arize AX tracing to an app. Two-phase flow: analyze codebase, then implement instrumentation (uses [Agent-Assisted Tracing](https://arize.com/docs/ax/alyx/tracing-assistant)). |
-| [arize-span-routing](skills/arize-span-routing/SKILL.md) | Route Python spans from custom agent builders or multi-tenant apps to different Arize spaces and projects using application metadata. |
+| [arize-span-routing](skills/arize-span-routing/SKILL.md) | Send each agent's or tenant's Python spans to its correct Arize space and project using application metadata. |
 | [arize-dataset](skills/arize-dataset/SKILL.md) | Create, manage, and download datasets and examples. |
 | [arize-experiment](skills/arize-experiment/SKILL.md) | Run and analyze experiments against datasets. |
 | [arize-evaluator](skills/arize-evaluator/SKILL.md) | Create LLM-as-judge evaluators, run evaluation tasks, and set up continuous monitoring. |

--- a/skills/arize-span-routing/SKILL.md
+++ b/skills/arize-span-routing/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arize-span-routing
-description: Routes Python OpenTelemetry spans from custom agent builders or multi-tenant applications to different Arize spaces and projects using application metadata. Use when one service must dynamically select an Arize destination per agent, tenant, team, or request, or when the user mentions register_with_routing, set_routing_context, multi-space tracing, or custom span routing.
+description: Use when one Python service must send each agent's, tenant's, team's, or request's spans to its correct Arize space and project using application metadata. Covers dynamic OpenTelemetry routing for custom agent builders and multi-tenant applications, including register_with_routing, set_routing_context, multi-space tracing, and custom span routing.
 metadata:
   author: arize
   version: "1.0"
@@ -9,7 +9,7 @@ compatibility: Requires Python, arize-otel 0.11.0 or newer, and one Arize API ke
 
 # Arize Span Routing Skill
 
-Use this skill to add dynamic, pre-export routing to a Python application. Each traced operation must resolve to exactly one Arize `space_id` and `project_name` before its first span starts.
+Use this skill to send each traced operation from one Python service to its correct Arize space and project. Each operation must resolve to exactly one `space_id` and `project_name` before its first span starts.
 
 Do not use this skill for ordinary single-project tracing; use `arize-instrumentation`. This skill does not reroute spans after export, backfill historical spans, create Arize spaces/projects, or invent a customer-specific metadata mapping.
 
@@ -135,7 +135,7 @@ All auto-instrumented and manual child spans created inside the routing context 
 
 For background work, propagate the OpenTelemetry context explicitly or resolve and enter a new routing context in the worker. Never rely on request-local context after a queue or thread boundary.
 
-See `references/REFERENCE.md` for existing-provider details, concurrency rules, testing, verification, and troubleshooting.
+See `references/REFERENCE.md` for agent experiment endpoints, existing-provider details, concurrency rules, testing, verification, and troubleshooting.
 
 ## Verification
 

--- a/skills/arize-span-routing/SKILL.md
+++ b/skills/arize-span-routing/SKILL.md
@@ -1,0 +1,164 @@
+---
+name: arize-span-routing
+description: Routes Python OpenTelemetry spans from custom agent builders or multi-tenant applications to different Arize spaces and projects using application metadata. Use when one service must dynamically select an Arize destination per agent, tenant, team, or request, or when the user mentions register_with_routing, set_routing_context, multi-space tracing, or custom span routing.
+metadata:
+  author: arize
+  version: "1.0"
+compatibility: Requires Python, arize-otel 0.11.0 or newer, and one Arize API key authorized for every destination space.
+---
+
+# Arize Span Routing Skill
+
+Use this skill to add dynamic, pre-export routing to a Python application. Each traced operation must resolve to exactly one Arize `space_id` and `project_name` before its first span starts.
+
+Do not use this skill for ordinary single-project tracing; use `arize-instrumentation`. This skill does not reroute spans after export, backfill historical spans, create Arize spaces/projects, or invent a customer-specific metadata mapping.
+
+## Safety rules
+
+- Never guess a destination or silently use another tenant's destination.
+- Never embed API keys in code or ask users to paste keys into chat. Read `ARIZE_API_KEY` from the environment.
+- Preserve existing non-Arize exporters and processors. Remove or replace a fixed-destination Arize export path so routed spans are not also copied to that destination.
+- Missing, invalid, or unavailable routing metadata must leave the business operation running but its spans unexported to Arize. Run that operation under a fresh OpenTelemetry context so stale routing values cannot leak across tenants. Log a warning without including secrets or sensitive metadata values.
+- Use one API key that is authorized for every destination space. Stop and report a credential blocker if that is not true.
+
+## Phase 1: Inspect and define the contract
+
+Read only until the routing contract is clear.
+
+1. Identify the exact Python service and entrypoint to change.
+2. Find current tracing initialization, provider/exporters, instrumentors, and client creation order.
+3. Find the request or agent-execution boundary that owns destination metadata.
+4. Identify the stable metadata field(s) and existing source of truth that resolve to:
+   - Arize `space_id`
+   - Arize `project_name`
+5. Check async tasks, thread pools, queues, or background workers that may outlive the request context.
+6. Find the app's test command and existing test style.
+
+Inspect only the target app's configuration. Do not search unrelated repositories, sibling services, shell startup files, or arbitrary `.env` files for credentials.
+
+If service scope, metadata fields, mapping source, or destination behavior is ambiguous, stop and ask the minimum question needed. Do not install packages or edit code first. If the user requested implementation and all four are clear, summarize the contract briefly and continue.
+
+## Phase 2: Implement
+
+### 1. Ensure routing support exists
+
+Use the project's package manager to require `arize-otel>=0.11.0`. Do not change unrelated dependencies.
+
+### 2. Initialize routing once
+
+For an app without an existing OpenTelemetry provider, initialize routing before instrumentors and LLM clients:
+
+```python
+import os
+
+from arize.otel import register_with_routing
+
+tracer_provider = register_with_routing(
+    api_key=os.environ["ARIZE_API_KEY"],
+)
+```
+
+If the app already owns a provider with non-Arize telemetry, keep it and add the routing processor:
+
+```python
+import os
+
+from arize.otel import ArizeRoutingSpanProcessor, Endpoint, Transport
+
+tracer_provider.add_span_processor(
+    ArizeRoutingSpanProcessor(
+        api_key=os.environ["ARIZE_API_KEY"],
+        endpoint=Endpoint.ARIZE,
+        transport=Transport.GRPC,
+    )
+)
+```
+
+Reuse the app's configured endpoint and transport when present. Never call `register_with_routing` after another global provider has already been installed. If the provider also has a fixed Arize processor/exporter, remove that fixed path in its initialization before adding routing; OpenTelemetry processors cannot be safely removed after startup.
+
+### 3. Resolve one routing target
+
+Adapt the app's existing metadata model; do not introduce a framework for one lookup. The resolver must return both non-empty values or no target. Keep mapping data in its existing source of truth rather than duplicating it in tracing code.
+
+```python
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RoutingTarget:
+    space_id: str
+    project_name: str
+```
+
+Use this type only when the codebase lacks an equivalent. Validate the result before any traced work begins.
+
+### 4. Set context around the complete operation
+
+Enter routing context at the highest boundary that has the metadata and encloses every child span:
+
+Replace `RoutingLookupError` below with the resolver's specific existing lookup/configuration exception.
+
+```python
+from opentelemetry import context as context_api
+from arize.otel import set_routing_context
+
+
+def run_without_arize_routing(request):
+    token = context_api.attach(context_api.Context())
+    try:
+        return run_agent(request)
+    finally:
+        context_api.detach(token)
+
+
+def handle_agent_request(request):
+    try:
+        target = resolve_routing_target(request.agent_metadata)
+    except RoutingLookupError:
+        logger.warning("Arize routing lookup failed; spans will not be exported")
+        return run_without_arize_routing(request)
+
+    if target is None or not target.space_id or not target.project_name:
+        logger.warning("No Arize routing target; spans will not be exported")
+        return run_without_arize_routing(request)
+
+    with set_routing_context(
+        space_id=target.space_id,
+        project_name=target.project_name,
+    ):
+        return run_agent(request)
+```
+
+Catch only the resolver's expected lookup/configuration exceptions; do not hide unrelated application failures. A fresh context on the no-target path intentionally prevents inherited routing values from reaching Arize. It may start a new trace for other exporters; tenant isolation takes priority. If preserving the distributed parent is mandatory, report the missing public routing-clear API as an SDK follow-up rather than using private context keys.
+
+All auto-instrumented and manual child spans created inside the routing context inherit `arize.space_id` and `arize.project.name`. Do not set routing after spans have started.
+
+For background work, propagate the OpenTelemetry context explicitly or resolve and enter a new routing context in the worker. Never rely on request-local context after a queue or thread boundary.
+
+See `references/REFERENCE.md` for existing-provider details, concurrency rules, testing, verification, and troubleshooting.
+
+## Verification
+
+1. Run focused unit tests for the resolver and execution boundary.
+2. Prove two different metadata values produce two different space/project pairs.
+3. Prove child spans inherit the selected pair.
+4. Prove concurrent operations cannot leak routing context.
+5. Prove unknown metadata and resolver failures clear inherited routing, export no spans to any fallback destination, and leave business logic running.
+6. Prove pre-existing non-Arize exporters/processors remain attached and no fixed Arize path remains.
+7. Trigger one uniquely named trace per target in non-production spaces.
+8. Use `arize-trace` with the same credential context to confirm each trace exists only in its intended destination.
+
+For short-lived scripts, call `force_flush()` and `shutdown()` before exit. Finish as **confirmed**, **confirmed with warnings**, or a precise blocker; never report completion from unit tests alone when live verification was requested.
+
+## Guardrails and limits
+
+- Both routing values are required. Spans missing either value are skipped.
+- `ArizeRoutingSpanProcessor` creates and caches one processor per unique space. Flag unbounded or high-cardinality space IDs before implementation.
+- Routing selects spaces and projects only; other customer metadata still belongs in normal OpenInference attributes.
+- If dogfooding exposes a missing `arize-otel` capability, stop and propose a separate SDK change instead of adding a compatibility hack.
+
+## Related skills
+
+- `arize-instrumentation`: first-time or single-destination tracing
+- `arize-trace`: post-export verification and debugging
+- `arize-admin`: inspect or manage authorized spaces and API keys

--- a/skills/arize-span-routing/references/REFERENCE.md
+++ b/skills/arize-span-routing/references/REFERENCE.md
@@ -1,0 +1,140 @@
+# Arize Span Routing Reference
+
+Load this reference when implementing an existing-provider integration, crossing concurrency boundaries, writing tests, or diagnosing skipped spans.
+
+## Runtime contract
+
+`arize-otel>=0.11.0` exposes:
+
+- `register_with_routing(...)`: creates a provider with one `ArizeRoutingSpanProcessor`.
+- `ArizeRoutingSpanProcessor(...)`: attaches dynamic routing to a provider the application already owns.
+- `set_routing_context(space_id, project_name)`: attaches both routing values to current OpenTelemetry context.
+
+At span start, the processor copies context values into span attributes:
+
+| Context value | Span attribute | Purpose |
+|---|---|---|
+| Space ID | `arize.space_id` | Selects destination space and its cached exporter processor |
+| Project name | `arize.project.name` | Selects project inside destination space |
+
+At span end, missing `arize.space_id` or `arize.project.name` causes that span to be skipped. One API key is reused for all destination-space exporters.
+
+## Choosing initialization path
+
+### No existing provider
+
+Use `register_with_routing` once, before any instrumentor or LLM client is initialized. Let the app's existing config determine endpoint, transport, batching, and console logging.
+
+### Existing provider
+
+Add `ArizeRoutingSpanProcessor` to the provider. Do not call `trace.set_tracer_provider` again. Preserve unrelated processors, but stop constructing any fixed-destination Arize processor/exporter in the same provider or every routed span may also be copied there.
+
+If the provider is hidden behind a framework integration, inspect its supported processor/exporter extension point. If no supported extension exists, report the integration gap rather than replacing the framework's provider.
+
+### Existing fixed Arize registration
+
+Replace the app's existing `register(space_id=..., project_name=...)` initialization with `register_with_routing(...)` only when every Arize-bound trace from that provider should use routing context. Make this change at initialization, before the global provider is installed. Preserve any unrelated custom processors by attaching them to the returned provider. Remove only fixed-destination arguments and imports made obsolete by this change.
+
+## Mapping rules
+
+The agent-builder platform remains source of truth. Prefer its existing registry, config service, or database lookup. The tracing integration should adapt the result, not own a duplicate routing table.
+
+A valid result contains two non-empty strings:
+
+```python
+RoutingTarget(
+    space_id="U3BhY2U6...",
+    project_name="support-agent",
+)
+```
+
+Do not confuse:
+
+- Space name with base64 `space_id`
+- Project display name with project ID
+- Customer/tenant ID with either Arize identifier
+
+If destinations must be resolved through Arize, use the existing authenticated profile without changing it:
+
+```bash
+ax spaces list -o json
+ax projects list --space SPACE -l 100 -o json
+```
+
+Never persist a discovered mapping without user confirmation.
+
+## Missing mapping behavior
+
+Default behavior protects tenant isolation and application availability:
+
+1. Emit a bounded warning containing the metadata field name or stable internal identifier, not sensitive contents.
+2. Attach a fresh `opentelemetry.context.Context()` while business logic runs, then detach it in `finally`.
+3. Allow the routing processor to skip spans that now have no routing attributes.
+4. Do not use a default space or project.
+
+Handle the resolver's documented lookup/configuration exceptions identically. Do not catch broad application exceptions. Merely running outside a new `set_routing_context` is unsafe because ambient context can still contain routing values inherited from an outer request or copied worker context.
+
+Only implement a fallback destination when the user explicitly requests one and confirms that cross-tenant data placement is acceptable.
+
+## Context and concurrency
+
+`set_routing_context` uses OpenTelemetry context and reliably scopes ordinary nested spans. Verify boundaries where execution leaves current context:
+
+- Async tasks created inside current context usually inherit it; test the app's actual task pattern.
+- Thread-pool work may require `contextvars.copy_context()` or explicit target propagation.
+- Queued/background jobs should carry stable routing input and resolve a fresh target in the worker.
+- Detached callbacks must not retain a completed request's target.
+
+Never store current target in a process-global mutable variable.
+
+## Test design
+
+Prefer behavior tests at the app's routing boundary. Avoid testing private `arize-otel` internals.
+
+Required cases:
+
+1. Known agent A resolves to space A/project A.
+2. Known agent B resolves to space B/project B.
+3. Child spans receive matching `arize.space_id` and `arize.project.name`.
+4. Interleaved or concurrent A/B requests keep distinct values.
+5. Unknown, incomplete, and empty mappings clear inherited routing and produce no routed export.
+6. Expected resolver lookup failure clears inherited routing and does not break business execution.
+7. Existing non-Arize processors/exporters remain active, with no fixed Arize export path.
+8. Short-lived process flushes before shutdown.
+
+Use an in-memory exporter or a recording processor for unit tests. Mock destination I/O, not the resolver or execution boundary under test.
+
+## Live verification
+
+Use two non-production destinations accessible by the same API key.
+
+1. Emit a unique request/span name for target A.
+2. Emit another unique name for target B.
+3. Flush the provider when the app is short-lived.
+4. Use `arize-trace` to inspect each project using the same credentials used for export.
+5. Confirm A appears in A and not B; confirm B appears in B and not A.
+6. Exercise unknown metadata and confirm neither destination receives it.
+
+Do not use production spaces for autonomous verification.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Action |
+|---|---|---|
+| Warning says `arize.space_id` is missing | Context not entered before span start, or lost across concurrency boundary | Move context outward or propagate/resolve in worker |
+| Project-name warning and skipped span | Resolver returned incomplete target | Require both values before entering context |
+| Every request routes to same destination | Fixed `register(...)` setup remains, or mapping ignores request metadata | Inspect initialization and resolver input |
+| Traces appear in wrong tenant | Global mutable target, fallback destination, or context leak | Disable fallback; add concurrent isolation test |
+| Existing telemetry disappears | Existing provider/exporter was replaced | Restore provider; attach routing processor instead |
+| Authentication errors for some spaces | Shared API key lacks access to every target | Use an appropriately authorized key; do not add per-target secrets silently |
+| Memory grows with tenants | High-cardinality space IDs create cached processors | Validate bounded space count; open SDK follow-up if eviction is needed |
+| Short script emits nothing | Batch processor did not flush | Call `force_flush()` then `shutdown()` |
+
+## Out of scope
+
+- JavaScript/TypeScript parity
+- Creating spaces, projects, or API keys
+- Post-ingestion movement or historical backfills
+- Per-destination API keys
+- Arbitrary metadata transformation framework
+- Changes to `arize-otel` runtime APIs

--- a/skills/arize-span-routing/references/REFERENCE.md
+++ b/skills/arize-span-routing/references/REFERENCE.md
@@ -1,6 +1,16 @@
 # Arize Span Routing Reference
 
-Load this reference when implementing an existing-provider integration, crossing concurrency boundaries, writing tests, or diagnosing skipped spans.
+Load this reference when implementing an Arize agent experiment endpoint or existing-provider integration, crossing concurrency boundaries, writing tests, or diagnosing skipped spans.
+
+## Agent experiment endpoints
+
+For an Arize agent experiment endpoint, use the official tracing-context guide for the request contract and distributed parent-context steps:
+
+https://arize.com/docs/ax/improve/agent-tracing-context
+
+That workflow requires both W3C `traceparent` propagation and per-request space/project routing. Follow the guide to extract and attach the incoming parent context, then apply the routing rules below before starting spans. This skill covers routing only; it does not replace parent-context propagation.
+
+The guide describes environment defaults as one possible fallback. For a multi-tenant service, keep this skill's stricter default: missing or invalid routing must not send spans to another destination. Use a fallback only when the user explicitly requests one and confirms that cross-tenant data placement is acceptable.
 
 ## Runtime contract
 

--- a/tests/test_skill_selection.py
+++ b/tests/test_skill_selection.py
@@ -55,6 +55,22 @@ SPECIFIC_PROMPTS = [
         ["arize-instrumentation"],
         ["specific", "instrumentation"],
     ),
+    # arize-span-routing
+    (
+        "Route each agent's Python spans to its assigned Arize space and project",
+        ["arize-span-routing"],
+        ["specific", "span-routing"],
+    ),
+    (
+        "Use register_with_routing and set_routing_context in my custom agent builder",
+        ["arize-span-routing"],
+        ["specific", "span-routing"],
+    ),
+    (
+        "Send each tenant's traces to a different Arize space based on request metadata",
+        ["arize-span-routing"],
+        ["specific", "span-routing"],
+    ),
     # arize-dataset
     (
         "Create a new evaluation dataset with 10 examples",
@@ -275,6 +291,17 @@ VAGUE_PROMPTS = [
         "Help me instrument traces",
         ["arize-instrumentation"],
         ["vague", "instrumentation", "scope"],
+    ),
+    # Should route to span routing
+    (
+        "My agent platform needs traces to land in different customer workspaces",
+        ["arize-span-routing"],
+        ["vague", "span-routing"],
+    ),
+    (
+        "We run many agents in one Python service and each has its own Arize project",
+        ["arize-span-routing"],
+        ["vague", "span-routing"],
     ),
     # Should route to dataset
     (


### PR DESCRIPTION
### TL;DR

Agent-builder platforms need one Python service to send traces to different Arize spaces/projects from their own metadata; today that means bespoke exporters and per-customer backfills. Adds `arize-span-routing` so agents can wire `register_with_routing` / `set_routing_context` (`arize-otel>=0.11.0`) with isolation and verification guardrails. Fixes Arize-ai/arize#77901.

**Files to review (~330 lines):**

| File | Why |
|---|---|
| `SKILL.md` *(start here)* | Contract, safety rules, init + `set_routing_context` workflow |
| `REFERENCE.md` | Existing-provider path, concurrency, tests, troubleshooting |
| `test_skill_selection.py` | 5 prompts so the skill is selected for routing asks |
| `README.md` | Catalog row |

## Why

https://github.com/Arize-ai/arize/issues/77901 asks for a self-serve skill/module for customers (Tempus, pattern also seen at Uber/Optum) who route spans from agent-builder metadata instead of a fixed Arize destination. Skill covers the agent-installable half; SDK surface already ships in `arize-otel`.

## How

1. Skill gates on multi-destination / custom-builder cases and defers single-project tracing to `arize-instrumentation`.
2. Phase 1 forces a clear metadata → `(space_id, project_name)` contract before edits.
3. Phase 2 chooses `register_with_routing` or `ArizeRoutingSpanProcessor`, then wraps the full operation in `set_routing_context`.
4. Missing/invalid routing clears inherited context and skips Arize export without failing the business call.

## Reviewer notes

- **Cross-repo close:** `Fixes Arize-ai/arize#77901` targets the product issue from this skills repo.
- **Credential model:** one API key authorized for every destination space; skill stops on that blocker rather than inventing multi-key routing.
- **Focus area:** safety rules around tenant isolation and “no silent fallback destination” — does the wording match what `arize-otel` actually does?

## Tests

Selection harness gains 3 specific + 2 vague prompts for `arize-span-routing`. Run: existing `tests/test_skill_selection.py` path used in CI.
