### PR TITLE
Single Install Command to Install Skills + Trace, default to skills non-interactive mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,27 +10,31 @@ Works with Cursor, Claude Code, Codex, GitHub Copilot, Windsurf, and [40+ other 
 
 **Adding tracing to your app** — give your coding agent this prompt:
 
-> Follow the instructions from https://arize.com/docs/PROMPT.md and ask me questions as needed.
+> Install Arize skills from github.com/Arize-ai/arize-skills and use the arize-instrumentation skill to add tracing to this application.
 
-This walks through a two-phase flow: analyze your codebase for LLM providers and frameworks, then add Arize AX tracing with the right instrumentors. No skill installation needed.
+The agent installs the skills, instruments your app, and verifies a trace reaches Arize AX — all in one session. You'll just need to provide your Arize credentials and approve the code changes.
 
 **Already have traces?** Give your agent this prompt to install the skills and start debugging:
 
-> Install the Arize skills plugin from https://github.com/Arize-ai/arize-skills, then use the arize-trace skill to export and analyze recent traces from my project. Summarize any errors or latency issues you find.
+> Install Arize skills from github.com/Arize-ai/arize-skills, then use the arize-trace skill to export and analyze recent traces from my project. Summarize any errors or latency issues you find.
 
 ## Installation
 
 ### Option 1: npx (recommended)
 
-```bash
-# Interactive — choose skills, agent, and scope
-npx skills add Arize-ai/arize-skills
+Install all skills non-interactively — this is what the agent runs for the prompt above:
 
-# Non-interactive — install everything with auto-detected defaults
+```bash
 npx skills add Arize-ai/arize-skills --skill "*" --yes
 ```
 
-Both options auto-detect your agent (Cursor, Claude Code, Codex, etc.) and symlink skills into place.
+Want to hand-pick skills, agent, and scope yourself? Drop the flags for the interactive wizard:
+
+```bash
+npx skills add Arize-ai/arize-skills
+```
+
+Both auto-detect your agent (Cursor, Claude Code, Codex, etc.) and symlink skills into place.
 
 ### Option 2: git clone
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ Works with Cursor, Claude Code, Codex, GitHub Copilot, Windsurf, and [40+ other 
 
 **Adding tracing to your app** — give your coding agent this prompt:
 
-> Install Arize skills from github.com/Arize-ai/arize-skills and use the arize-instrumentation skill to add tracing to this application.
+> Install Arize skills from https://github.com/Arize-ai/arize-skills and use the arize-instrumentation skill to add tracing to this application.
 
 The agent installs the skills, instruments your app, and verifies a trace reaches Arize AX — all in one session. You'll just need to provide your Arize credentials and approve the code changes.
 
 **Already have traces?** Give your agent this prompt to install the skills and start debugging:
 
-> Install Arize skills from github.com/Arize-ai/arize-skills, then use the arize-trace skill to export and analyze recent traces from my project. Summarize any errors or latency issues you find.
+> Install Arize skills from https://github.com/Arize-ai/arize-skills, then use the arize-trace skill to export and analyze recent traces from my project. Summarize any errors or latency issues you find.
 
 ## Installation
 


### PR DESCRIPTION
## What

Make the repo's onboarding consistent with the new AX "Get Started" UI: a single natural-language agent prompt that installs the Arize skills **and** instruments the app end-to-end.

See here for full spec: https://app.notion.com/p/Single-Line-Command-to-Trace-d356a532fadd4254afad5071a5dabd44

`README.md`-only change (4 edits):
- **"Adding tracing to your app"** now features the agent prompt: *"Install Arize skills from github.com/Arize-ai/arize-skills and use the arize-instrumentation skill to add tracing to this application."*
- Trimmed the explainer to one plain sentence.
- **Installation → Option 1**: the non-interactive `npx skills add … --skill "*" --yes` is presented as the default and explicitly tied to the prompt; interactive wizard demoted to an opt-in.
- Standardized wording on "skills" (dropped "plugin"), matched `github.com/…` URL style.
