### PR TITLE
docs(arize-instrumentation): complete the manual-span examples (minimal)

### DIFF
--- a/skills/arize-instrumentation/references/manual-spans.md
+++ b/skills/arize-instrumentation/references/manual-spans.md
@@ -96,22 +96,40 @@ def run_agent(user_message: str) -> str:
 **Context-manager alternative** — use this when you can't decorate a function: a tool dispatched dynamically by name in a loop, or a span kind with no decorator (RETRIEVER, EMBEDDING, etc.). (For `session.id`, use `using_session` — see [session-tracking.md](session-tracking.md) — not a wrapper span.) Tool spans nest as children of the CHAIN span:
 
 ```python
-from opentelemetry.trace import get_tracer
+from opentelemetry.trace import get_tracer, Status, StatusCode
 
-tracer = get_tracer("my-app")
+tracer = get_tracer("my-app")   # or reuse the OITracer from register()
 
 with tracer.start_as_current_span("run_agent") as chain_span:
     chain_span.set_attribute("openinference.span.kind", "CHAIN")
     chain_span.set_attribute("input.value", user_message)
     # ... LLM call ...
     for tool_use in tool_uses:
+        spec = tool_specs_by_name[tool_use["name"]]   # your own tool registry
         with tracer.start_as_current_span(tool_use["name"]) as tool_span:
             tool_span.set_attribute("openinference.span.kind", "TOOL")
+            tool_span.set_attribute("tool.name", tool_use["name"])
+            tool_span.set_attribute("tool.description", spec["description"])
+            tool_span.set_attribute("tool.parameters", json.dumps(spec["parameters"]))
             tool_span.set_attribute("input.value", json.dumps(tool_use["input"]))
             result = run_tool(tool_use["name"], tool_use["input"])
-            tool_span.set_attribute("output.value", result)
+            tool_span.set_attribute("output.value", json.dumps(result))
+            tool_span.set_status(Status(StatusCode.OK))   # REQUIRED: start_as_current_span never sets OK; without this the span exports UNSET
         # ... append tool result to messages, call LLM again ...
     chain_span.set_attribute("output.value", final_reply)
+    chain_span.set_status(Status(StatusCode.OK))   # REQUIRED on every manual span
+```
+
+A span kind with no decorator (RETRIEVER, EMBEDDING, …) is always hand-rolled. Set its status the same way — a raised exception is auto-marked `ERROR`, so you only add the `OK` line on success:
+
+```python
+with tracer.start_as_current_span("retrieve") as span:
+    span.set_attribute("openinference.span.kind", "RETRIEVER")
+    span.set_attribute("input.value", query)
+    docs = retrieve_documents(query)
+    span.set_attribute("output.value", json.dumps(docs))
+    span.set_status(Status(StatusCode.OK))   # REQUIRED — without this the span exports UNSET
+    return docs
 ```
 
 ## TypeScript / JavaScript pattern


### PR DESCRIPTION
## What

A **minimal, example-only** change over baseline: leave `SKILL.md`, `go.md`, and `verification.md` exactly as they are on `main`, and touch only the two Python manual-span code snippets in `references/manual-spans.md` so that a span copied verbatim is complete.

- Tool-loop example now sets `tool.name` + `tool.description` + `tool.parameters` (from a `tool_specs_by_name` lookup), JSON-encodes `output.value`, and calls `set_status(Status(StatusCode.OK))` on both the tool and chain spans — each marked `# REQUIRED` with the reason.
- Adds a short **RETRIEVER** example (no decorator exists for it) with the same `OK` line.

Diff: **1 file, +21/−3**, all inside code blocks.

## Why this instead of #120

PR #120 took the "grow" approach — decorator-first reframing and mandatory-rule prose across four files. On the benchmark it landed **below baseline** (0.938 vs 0.946) with regressions on previously-clean apps, and the exact failures it targeted (manual TOOL spans missing `tool.description`/`tool.parameters`, RETRIEVER/CHAIN spans exporting `UNSET`) persisted — agents authored spans from their priors and skimmed past the added prose.

This PR tests the opposite hypothesis: **a shorter skill with one complete, copy-pasteable snippet beats more guidance.** If agents lift the example, they get a complete span; if they don't, at least the skill isn't longer/denser than the baseline that scored higher.

## Validation

Deliberately **not** claiming local validation — my in-session subagent tests gave false positives on #120. This needs a real benchmark run to judge against baseline. Recommend benchmarking this branch head-to-head with `main` and with #120 before merging either.

## Relationship to #120

Alternative approach to the same goal. If this scores better, #120 should be closed; if neither beats baseline, neither should merge.