### PR TITLE
feat: add project URLs to arize-link skill

### DIFF
--- a/skills/arize-link/SKILL.md
+++ b/skills/arize-link/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: arize-link
-description: Generates deep links to the Arize UI for traces, spans, sessions, datasets, labeling queues, evaluators, and annotation configs. Produces clickable URLs for sharing Arize resources with team members. Use when the user wants to link to or open a trace, span, session, dataset, evaluator, or annotation config in the Arize UI.
+description: Generates deep links to the Arize UI for projects, traces, spans, sessions, datasets, labeling queues, evaluators, and annotation configs. Discovers organization and project IDs with the ax CLI and produces clickable URLs for sharing Arize resources with team members. Use when the user wants to link to or open a project, trace, span, session, dataset, evaluator, or annotation config in the Arize UI.
 metadata:
   author: arize
   version: "1.0"
@@ -8,17 +8,17 @@ metadata:
 
 # Arize Link
 
-Generate deep links to the Arize UI for traces, spans, sessions, datasets, labeling queues, evaluators, and annotation configs.
+Generate deep links to the Arize UI for projects, traces, spans, sessions, datasets, labeling queues, evaluators, and annotation configs.
 
 ## When to Use
 
-- User wants a link to a trace, span, session, dataset, labeling queue, evaluator, or annotation config
+- User wants a link to a project, trace, span, session, dataset, labeling queue, evaluator, or annotation config
 - You have IDs from exported data or logs and need to link back to the UI
 - User asks to "open" or "view" any of the above in Arize
 
 ## Required Inputs
 
-Collect from the user or context (exported trace data, parsed URLs):
+Collect from the user, context (exported trace data or parsed URLs), or the `ax` CLI:
 
 | Always required | Resource-specific |
 |---|---|
@@ -28,11 +28,34 @@ Collect from the user or context (exported trace data, parsed URLs):
 | | `queue_id` — specific queue (omit for list) |
 | | `evaluator_id` [+ `version`] — evaluator |
 
+### Discover organization and project IDs
+
+Prefer the CLI over asking the user for IDs that it can provide:
+
+```bash
+ax organizations list --output json
+```
+
+Use `.organizations[].id` for the organization ID. If more than one organization is returned, match the user-provided organization name or ask them to choose.
+
+To discover a project ID, list projects in the relevant space:
+
+```bash
+ax projects list --space "{space_name_or_id}" --limit 100 --output json
+```
+
+Use the matching project's `id`; its `space_id` supplies the space ID required in the URL. The command accepts a space name or ID; if no space is known, run `ax projects list --limit 100 --output json` and select the matching project.
+
 **All path IDs must be base64-encoded** (characters: `A-Za-z0-9+/=`). A raw numeric ID produces a valid-looking URL that 404s. If the user provides a number, ask them to copy the ID directly from their Arize browser URL (`https://app.arize.com/organizations/{org_id}/spaces/{space_id}/…`). If you have a raw internal ID (e.g. `Organization:1:abC1`), base64-encode it before inserting into the URL.
 
 ## URL Templates
 
 Base URL: `https://app.arize.com` (override for on-prem)
+
+**Project:**
+```
+{base_url}/organizations/{org_id}/spaces/{space_id}/projects/{project_id}
+```
 
 **Trace** (add `&selectedSpanId={span_id}` to highlight a specific span):
 ```
@@ -80,9 +103,9 @@ Prefer tight windows; 90-day windows load slowly.
 
 ## Instructions
 
-1. Gather IDs from user, exported data, or URL context.
+1. Gather IDs from user, exported data, URL context, or the CLI. Use `ax organizations list --output json` to obtain `org_id`; use `ax projects list` to obtain `project_id` when needed.
 2. Verify all path IDs are base64-encoded.
-3. Determine `startA`/`endA` using the priority order above.
+3. Determine `startA`/`endA` using the priority order above for trace, span, and session links.
 4. Substitute into the appropriate template and present as a clickable markdown link.
 
 ## Troubleshooting
@@ -90,9 +113,9 @@ Prefer tight windows; 90-day windows load slowly.
 | Problem | Solution |
 |---|---|
 | "No data" / empty view | Trace outside time window — widen `startA`/`endA` (±1h → ±1d → 90d). |
-| 404 | ID wrong or not base64. Re-check `org_id`, `space_id`, `project_id` from the browser URL. |
+| 404 | ID wrong or not base64. Re-check `org_id` with `ax organizations list --output json`, `project_id` with `ax projects list`, and `space_id` from the browser URL. |
 | Span not highlighted | `span_id` may belong to a different trace. Verify against exported span data. |
-| `org_id` unknown | `ax` CLI doesn't expose it. Ask user to copy from `https://app.arize.com/organizations/{org_id}/spaces/{space_id}/…`. |
+| `org_id` unknown | Run `ax organizations list --output json` and use `.organizations[].id`. If the CLI cannot access the organization, ask the user to copy it from their Arize browser URL. |
 
 ## Related Skills
 

--- a/skills/arize-link/references/EXAMPLES.md
+++ b/skills/arize-link/references/EXAMPLES.md
@@ -8,6 +8,12 @@ Placeholders used throughout:
 
 ---
 
+## Project
+
+```
+https://app.arize.com/organizations/{org_id}/spaces/{space_id}/projects/{project_id}
+```
+
 ## Trace
 
 ```


### PR DESCRIPTION
## Summary
- discover organization IDs through ax organizations list JSON output
- discover project and space IDs through ax projects list
- add direct project URL guidance and examples

## Testing
- bash scripts/check.sh
- git diff --check
- live ax organization and project discovery
- HTTP HEAD smoke test for an assembled project URL